### PR TITLE
Capture Hermes + OpenCode schema DDL as test fixtures

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,34 @@
+//! Shared test helpers for building temporary SQLite databases from schema
+//! fixture files (see `tests/fixtures/`).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+use tempfile::TempDir;
+
+/// Creates a fresh temp SQLite database, applies the DDL in `schema_path`
+/// to it, and returns the owning [`TempDir`] (keep it alive for as long as
+/// the database is needed — dropping it deletes the file) along with the
+/// database's path.
+pub fn temp_db_from_schema(schema_path: &Path) -> (TempDir, PathBuf) {
+    let schema = fs::read_to_string(schema_path)
+        .unwrap_or_else(|e| panic!("failed to read schema fixture {schema_path:?}: {e}"));
+
+    let dir = TempDir::new().expect("create temp dir");
+    let db_path = dir.path().join("test.db");
+
+    let conn = Connection::open(&db_path).expect("open temp sqlite db");
+    conn.execute_batch(&schema)
+        .unwrap_or_else(|e| panic!("failed to apply schema {schema_path:?}: {e}"));
+
+    (dir, db_path)
+}
+
+/// Path to a fixture file under `tests/fixtures/`.
+pub fn fixture_path(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}

--- a/tests/fixtures/hermes_schema.sql
+++ b/tests/fixtures/hermes_schema.sql
@@ -1,0 +1,97 @@
+-- Hermes state.db schema fixture.
+--
+-- Captured live, read-only, schema only (no rows) via:
+--   sqlite3 "file:~/.hermes/state.db?mode=ro" .schema
+--
+-- Trimmed to the tables hermon.py reads (HermesSource, hermon.py:530):
+-- `sessions` and `messages`, plus their indexes. The live database has
+-- several other tables (schema_version, state_meta, gateway_routing,
+-- compression_locks, messages_fts*, async_delegations,
+-- session_model_usage) that hermon never queries; they are omitted here
+-- for a smaller, faithful fixture.
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    source TEXT NOT NULL,
+    user_id TEXT,
+    session_key TEXT,
+    chat_id TEXT,
+    chat_type TEXT,
+    thread_id TEXT,
+    display_name TEXT,
+    origin_json TEXT,
+    expiry_finalized INTEGER DEFAULT 0,
+    model TEXT,
+    model_config TEXT,
+    system_prompt TEXT,
+    parent_session_id TEXT,
+    started_at REAL NOT NULL,
+    ended_at REAL,
+    end_reason TEXT,
+    message_count INTEGER DEFAULT 0,
+    tool_call_count INTEGER DEFAULT 0,
+    input_tokens INTEGER DEFAULT 0,
+    output_tokens INTEGER DEFAULT 0,
+    cache_read_tokens INTEGER DEFAULT 0,
+    cache_write_tokens INTEGER DEFAULT 0,
+    reasoning_tokens INTEGER DEFAULT 0,
+    cwd TEXT,
+    git_branch TEXT,
+    git_repo_root TEXT,
+    billing_provider TEXT,
+    billing_base_url TEXT,
+    billing_mode TEXT,
+    estimated_cost_usd REAL,
+    actual_cost_usd REAL,
+    cost_status TEXT,
+    cost_source TEXT,
+    pricing_version TEXT,
+    title TEXT,
+    api_call_count INTEGER DEFAULT 0,
+    handoff_state TEXT,
+    handoff_platform TEXT,
+    handoff_error TEXT,
+    compression_failure_cooldown_until REAL,
+    compression_failure_error TEXT,
+    rewind_count INTEGER NOT NULL DEFAULT 0,
+    archived INTEGER NOT NULL DEFAULT 0, "compression_fallback_streak" INTEGER NOT NULL DEFAULT 0, "profile_name" TEXT, "compression_ineffective_count" INTEGER NOT NULL DEFAULT 0, "pinned" INTEGER NOT NULL DEFAULT 0, "last_activity_at" REAL, "last_activity_description" TEXT, "last_activity_provenance" TEXT,
+    FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+);
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    role TEXT NOT NULL,
+    content TEXT,
+    tool_call_id TEXT,
+    tool_calls TEXT,
+    tool_name TEXT,
+    timestamp REAL NOT NULL,
+    token_count INTEGER,
+    finish_reason TEXT,
+    reasoning TEXT,
+    reasoning_content TEXT,
+    reasoning_details TEXT,
+    codex_reasoning_items TEXT,
+    codex_message_items TEXT,
+    platform_message_id TEXT,
+    observed INTEGER DEFAULT 0,
+    active INTEGER NOT NULL DEFAULT 1,
+    compacted INTEGER NOT NULL DEFAULT 0
+, "effect_disposition" TEXT, "api_content" TEXT, "display_kind" TEXT, "display_metadata" TEXT);
+CREATE INDEX idx_sessions_source ON sessions(source);
+CREATE INDEX idx_sessions_source_id ON sessions(source, id);
+CREATE INDEX idx_sessions_parent ON sessions(parent_session_id);
+CREATE INDEX idx_sessions_started ON sessions(started_at DESC);
+CREATE INDEX idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX idx_messages_platform_msg_id ON messages(session_id, platform_message_id) WHERE platform_message_id IS NOT NULL;
+CREATE INDEX idx_messages_session_active
+    ON messages(session_id, active, timestamp);
+CREATE INDEX idx_sessions_session_key
+    ON sessions(session_key, started_at DESC);
+CREATE INDEX idx_sessions_gateway_peer
+    ON sessions(source, user_id, chat_id, chat_type, thread_id, started_at DESC);
+CREATE INDEX idx_sessions_handoff_state
+    ON sessions(handoff_state, started_at);
+CREATE UNIQUE INDEX idx_sessions_title_unique ON sessions(title) WHERE title IS NOT NULL;
+CREATE INDEX idx_messages_active_null
+    ON messages(active) WHERE active IS NULL;
+CREATE INDEX idx_messages_session_id ON messages(session_id, id);

--- a/tests/fixtures/opencode_schema.sql
+++ b/tests/fixtures/opencode_schema.sql
@@ -1,0 +1,64 @@
+-- OpenCode opencode.db schema fixture.
+--
+-- Captured live, read-only, schema only (no rows) via:
+--   sqlite3 "file:~/.local/share/opencode/opencode.db?mode=ro" .schema
+--
+-- Path note: hermon.py's default is the Linux XDG path
+-- ~/.local/share/opencode/opencode.db. On this machine that same path
+-- exists and holds the live database, so no macOS-specific path
+-- (e.g. ~/Library/Application Support/opencode/) was needed.
+--
+-- Trimmed to the tables hermon.py reads (OpenCodeSource, hermon.py:615):
+-- `session`, `message`, and `part`, plus their indexes. The live database
+-- has many other tables (project, todo, session_share, control_account,
+-- account, account_state, event_sequence, event, workspace,
+-- session_message, data_migration, permission, project_directory,
+-- session_input, session_context_epoch, migration) that hermon never
+-- queries; they are omitted here for a smaller, faithful fixture. Foreign
+-- keys on the kept tables that reference an omitted table (e.g.
+-- session.project_id -> project(id)) are left as-is; SQLite does not
+-- require the referenced table to exist to create the table.
+CREATE TABLE `message` (
+          `id` text PRIMARY KEY,
+          `session_id` text NOT NULL,
+          `time_created` integer NOT NULL,
+          `time_updated` integer NOT NULL,
+          `data` text NOT NULL,
+          CONSTRAINT `fk_message_session_id_session_id_fk` FOREIGN KEY (`session_id`) REFERENCES `session`(`id`) ON DELETE CASCADE
+        );
+CREATE TABLE `part` (
+          `id` text PRIMARY KEY,
+          `message_id` text NOT NULL,
+          `session_id` text NOT NULL,
+          `time_created` integer NOT NULL,
+          `time_updated` integer NOT NULL,
+          `data` text NOT NULL,
+          CONSTRAINT `fk_part_message_id_message_id_fk` FOREIGN KEY (`message_id`) REFERENCES `message`(`id`) ON DELETE CASCADE
+        );
+CREATE TABLE `session` (
+          `id` text PRIMARY KEY,
+          `project_id` text NOT NULL,
+          `parent_id` text,
+          `slug` text NOT NULL,
+          `directory` text NOT NULL,
+          `title` text NOT NULL,
+          `version` text NOT NULL,
+          `share_url` text,
+          `summary_additions` integer,
+          `summary_deletions` integer,
+          `summary_files` integer,
+          `summary_diffs` text,
+          `revert` text,
+          `permission` text,
+          `time_created` integer NOT NULL,
+          `time_updated` integer NOT NULL,
+          `time_compacting` integer,
+          `time_archived` integer, `workspace_id` text, `path` text, `agent` text, `model` text, `cost` real DEFAULT 0 NOT NULL, `tokens_input` integer DEFAULT 0 NOT NULL, `tokens_output` integer DEFAULT 0 NOT NULL, `tokens_reasoning` integer DEFAULT 0 NOT NULL, `tokens_cache_read` integer DEFAULT 0 NOT NULL, `tokens_cache_write` integer DEFAULT 0 NOT NULL, `metadata` text,
+          CONSTRAINT `fk_session_project_id_project_id_fk` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE CASCADE
+        );
+CREATE INDEX `part_session_idx` ON `part` (`session_id`);
+CREATE INDEX `session_project_idx` ON `session` (`project_id`);
+CREATE INDEX `session_parent_idx` ON `session` (`parent_id`);
+CREATE INDEX `session_workspace_idx` ON `session` (`workspace_id`);
+CREATE INDEX `message_session_time_created_id_idx` ON `message` (`session_id`,`time_created`,`id`);
+CREATE INDEX `part_message_id_id_idx` ON `part` (`message_id`,`id`);

--- a/tests/schema_fixtures.rs
+++ b/tests/schema_fixtures.rs
@@ -1,0 +1,39 @@
+//! Smoke tests proving the captured schema fixtures build into a working
+//! temp SQLite database with the tables hermon reads.
+
+mod common;
+
+use rusqlite::Connection;
+
+use common::{fixture_path, temp_db_from_schema};
+
+fn table_names(conn: &Connection) -> Vec<String> {
+    let mut stmt = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+        .expect("prepare sqlite_master query");
+    stmt.query_map([], |row| row.get::<_, String>(0))
+        .expect("query sqlite_master")
+        .collect::<Result<_, _>>()
+        .expect("collect table names")
+}
+
+#[test]
+fn hermes_schema_builds_with_expected_tables() {
+    let (_dir, db_path) = temp_db_from_schema(&fixture_path("hermes_schema.sql"));
+    let conn = Connection::open(&db_path).expect("reopen temp db");
+
+    let tables = table_names(&conn);
+    assert!(tables.contains(&"sessions".to_string()), "tables: {tables:?}");
+    assert!(tables.contains(&"messages".to_string()), "tables: {tables:?}");
+}
+
+#[test]
+fn opencode_schema_builds_with_expected_tables() {
+    let (_dir, db_path) = temp_db_from_schema(&fixture_path("opencode_schema.sql"));
+    let conn = Connection::open(&db_path).expect("reopen temp db");
+
+    let tables = table_names(&conn);
+    assert!(tables.contains(&"session".to_string()), "tables: {tables:?}");
+    assert!(tables.contains(&"message".to_string()), "tables: {tables:?}");
+    assert!(tables.contains(&"part".to_string()), "tables: {tables:?}");
+}


### PR DESCRIPTION
Closes #2

Stacked on #11 (issue-1-scaffold) — targets that branch, not main.

## Summary
- Captured schema DDL live and read-only from both real local databases on this machine:
  - `~/.hermes/state.db` → `tests/fixtures/hermes_schema.sql`
  - `~/.local/share/opencode/opencode.db` → `tests/fixtures/opencode_schema.sql` (the Linux XDG default path that `hermon.py` uses also exists and holds the live DB on this Mac, so no macOS-specific path was needed)
- Both captures are schema-only (`.schema` output against `sqlite_master`); no row data was read or copied.
- Trimmed each dump to the tables `hermon.py` actually reads plus their indexes: Hermes `sessions`/`messages` (`hermon.py:530` `HermesSource`), OpenCode `session`/`message`/`part` (`hermon.py:615` `OpenCodeSource`). Unrelated tables (FTS shadow tables, `project`, `todo`, `event`, etc.) were dropped for a smaller, faithful fixture.
- Added `tests/common/mod.rs`, a shared Rust test helper (`temp_db_from_schema`) that builds a temp SQLite DB from a schema file using `rusqlite` + `tempfile` (already scaffold deps), plus `tests/schema_fixtures.rs` with one smoke test per fixture proving the temp DB builds and the expected tables exist.

## Test plan
- `cargo test` — green, including the two new smoke tests (`hermes_schema_builds_with_expected_tables`, `opencode_schema_builds_with_expected_tables`).
- `python3 -m unittest discover -s tests` — green, 61 tests, unaffected.