### PR TITLE
Implement OpenCodeSource::sessions

### DIFF
--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -184,151 +184,267 @@ mod tests {
             // --- mirrors tests/test_hermes.py:250 TestHermesLiveness ---
             (
                 "ended wins over everything",
-                M { ended: true, age: 0.0, ..M::default() },
+                M {
+                    ended: true,
+                    age: 0.0,
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "turn_done is immediate regardless of recency",
-                M { turn_done: true, age: 0.0, ..M::default() },
+                M {
+                    turn_done: true,
+                    age: 0.0,
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "mid-turn recent is live",
-                M { age: 10.0, ..M::default() },
+                M {
+                    age: 10.0,
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "mid-turn beyond ceiling is done",
-                M { age: 999.0, ..M::default() },
+                M {
+                    age: 999.0,
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "tool_pending gets a longer ceiling (236s, real flicker case)",
-                M { tool_pending: true, age: 236.0, ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: 236.0,
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "tool_pending past its own ceiling, still fresh -> Stuck",
-                M { tool_pending: true, age: 901.0, ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: 901.0,
+                    ..M::default()
+                },
                 Attention(Stuck),
             ),
             // --- exact boundaries ---
             (
                 "plain ceiling boundary: age == idle_timeout is live",
-                M { age: IDLE, ..M::default() },
+                M {
+                    age: IDLE,
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "plain ceiling boundary: just past idle_timeout is done",
-                M { age: IDLE + 0.001, ..M::default() },
+                M {
+                    age: IDLE + 0.001,
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "tool-pending boundary: age == 5x ceiling is live",
-                M { tool_pending: true, age: CEILING, ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: CEILING,
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "fresh-window boundary: age == fresh_window is still Stuck",
-                M { tool_pending: true, age: FRESH, ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: FRESH,
+                    ..M::default()
+                },
                 Attention(Stuck),
             ),
             (
                 "past fresh_window the stuck session leaves as Done",
-                M { tool_pending: true, age: FRESH + 0.001, ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: FRESH + 0.001,
+                    ..M::default()
+                },
                 Done,
             ),
             // --- pending tool progression: Live -> Stuck -> Done ---
             (
                 "pending tool stays live past idle_timeout",
-                M { tool_pending: true, age: IDLE + 120.0, ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: IDLE + 120.0,
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "pending tool becomes Stuck past 5x idle_timeout",
-                M { tool_pending: true, age: CEILING + 100.0, ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: CEILING + 100.0,
+                    ..M::default()
+                },
                 Attention(Stuck),
             ),
             (
                 "pending tool becomes Done past fresh_window",
-                M { tool_pending: true, age: FRESH + 100.0, ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: FRESH + 100.0,
+                    ..M::default()
+                },
                 Done,
             ),
             // --- Stuck is only for a blown tool-pending ceiling ---
             (
                 "non-pending timeout within fresh_window is Done, not Stuck",
-                M { age: IDLE + 1.0, ..M::default() },
+                M {
+                    age: IDLE + 1.0,
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "ended + tool_pending is Done, never Stuck",
-                M { ended: true, tool_pending: true, age: 1_000.0, ..M::default() },
+                M {
+                    ended: true,
+                    tool_pending: true,
+                    age: 1_000.0,
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "turn_done + tool_pending, however stale, is Done, never Stuck",
-                M { turn_done: true, tool_pending: true, age: 1_000.0, ..M::default() },
+                M {
+                    turn_done: true,
+                    tool_pending: true,
+                    age: 1_000.0,
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "clean turn_done stays Done at any elapsed time",
-                M { turn_done: true, age: 100_000.0, ..M::default() },
+                M {
+                    turn_done: true,
+                    age: 100_000.0,
+                    ..M::default()
+                },
                 Done,
             ),
             // --- PermWait ---
             (
                 "ToolUse with 31s silence -> PermWait",
-                M { age: 31.0, last_event: tool_use(), ..M::default() },
+                M {
+                    age: 31.0,
+                    last_event: tool_use(),
+                    ..M::default()
+                },
                 Attention(PermWait),
             ),
             (
                 "ToolUse with 29s silence -> Live",
-                M { age: 29.0, last_event: tool_use(), ..M::default() },
+                M {
+                    age: 29.0,
+                    last_event: tool_use(),
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "ToolUse with exactly 30s silence -> Live (strictly greater)",
-                M { age: 30.0, last_event: tool_use(), ..M::default() },
+                M {
+                    age: 30.0,
+                    last_event: tool_use(),
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "last_event None never yields PermWait",
-                M { age: 31.0, ..M::default() },
+                M {
+                    age: 31.0,
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "ToolResult silence is Live, not PermWait",
-                M { age: 31.0, last_event: Some(LastEvent::ToolResult), ..M::default() },
+                M {
+                    age: 31.0,
+                    last_event: Some(LastEvent::ToolResult),
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "AssistantText silence is Live, not PermWait",
-                M { age: 31.0, last_event: Some(LastEvent::AssistantText), ..M::default() },
+                M {
+                    age: 31.0,
+                    last_event: Some(LastEvent::AssistantText),
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "User silence is Live, not PermWait",
-                M { age: 31.0, last_event: Some(LastEvent::User), ..M::default() },
+                M {
+                    age: 31.0,
+                    last_event: Some(LastEvent::User),
+                    ..M::default()
+                },
                 Live,
             ),
             (
                 "tool_pending + ToolUse silence while raw-live -> PermWait",
-                M { tool_pending: true, age: 236.0, last_event: tool_use(), ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: 236.0,
+                    last_event: tool_use(),
+                    ..M::default()
+                },
                 Attention(PermWait),
             ),
             (
                 "ended trumps PermWait even with ToolUse and silence",
-                M { ended: true, age: 31.0, last_event: tool_use(), ..M::default() },
+                M {
+                    ended: true,
+                    age: 31.0,
+                    last_event: tool_use(),
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "turn_done trumps PermWait even with ToolUse and silence",
-                M { turn_done: true, age: 31.0, last_event: tool_use(), ..M::default() },
+                M {
+                    turn_done: true,
+                    age: 31.0,
+                    last_event: tool_use(),
+                    ..M::default()
+                },
                 Done,
             ),
             (
                 "blown ceiling with ToolUse is Stuck, not PermWait",
-                M { tool_pending: true, age: CEILING + 100.0, last_event: tool_use(), ..M::default() },
+                M {
+                    tool_pending: true,
+                    age: CEILING + 100.0,
+                    last_event: tool_use(),
+                    ..M::default()
+                },
                 Attention(Stuck),
             ),
         ];
@@ -344,17 +460,53 @@ mod tests {
     fn raw_rule_matches_python_semantics() {
         // The private rule keeps pure live/done semantics: the same inputs
         // the Python matrix uses, checked against the bool directly.
-        assert!(!turn_liveness_raw(&meta(M { ended: true, ..M::default() }), NOW, IDLE));
-        assert!(!turn_liveness_raw(&meta(M { turn_done: true, ..M::default() }), NOW, IDLE));
-        assert!(turn_liveness_raw(&meta(M { age: 10.0, ..M::default() }), NOW, IDLE));
-        assert!(!turn_liveness_raw(&meta(M { age: 999.0, ..M::default() }), NOW, IDLE));
-        assert!(turn_liveness_raw(
-            &meta(M { tool_pending: true, age: 236.0, ..M::default() }),
+        assert!(!turn_liveness_raw(
+            &meta(M {
+                ended: true,
+                ..M::default()
+            }),
             NOW,
             IDLE
         ));
         assert!(!turn_liveness_raw(
-            &meta(M { tool_pending: true, age: 901.0, ..M::default() }),
+            &meta(M {
+                turn_done: true,
+                ..M::default()
+            }),
+            NOW,
+            IDLE
+        ));
+        assert!(turn_liveness_raw(
+            &meta(M {
+                age: 10.0,
+                ..M::default()
+            }),
+            NOW,
+            IDLE
+        ));
+        assert!(!turn_liveness_raw(
+            &meta(M {
+                age: 999.0,
+                ..M::default()
+            }),
+            NOW,
+            IDLE
+        ));
+        assert!(turn_liveness_raw(
+            &meta(M {
+                tool_pending: true,
+                age: 236.0,
+                ..M::default()
+            }),
+            NOW,
+            IDLE
+        ));
+        assert!(!turn_liveness_raw(
+            &meta(M {
+                tool_pending: true,
+                age: 901.0,
+                ..M::default()
+            }),
             NOW,
             IDLE
         ));

--- a/src/source/opencode.rs
+++ b/src/source/opencode.rs
@@ -1,1 +1,174 @@
 //! OpenCode state source (`~/.local/share/opencode/opencode.db`).
+//!
+//! OpenCode CLI sessions, from its own `opencode.db` (SQLite, WAL).
+//! OpenCode's `message.data.finish` is 'tool-calls' / 'stop' — the exact
+//! same signal as Hermes's `finish_reason`, so it plugs into the same
+//! turn-liveness logic via the shared [`SessionMeta`] shape. Two schema
+//! quirks bite: timestamps are epoch **milliseconds**, and turn state
+//! lives inside a JSON blob.
+//!
+//! Port of `hermon.py` `OpenCodeSource` (hermon.py:615).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+
+use super::SessionMeta;
+
+pub struct OpenCodeSource {
+    db_path: PathBuf,
+    warned: bool,
+}
+
+impl OpenCodeSource {
+    pub fn new(db_path: impl AsRef<Path>) -> Self {
+        Self {
+            db_path: expand_user(db_path.as_ref()),
+            warned: false,
+        }
+    }
+
+    /// Read-only connection, never writable — safe alongside the running
+    /// tool under WAL (port of `opencode_connect`, hermon.py:612).
+    fn connect(&self) -> rusqlite::Result<Connection> {
+        let conn = Connection::open_with_flags(
+            &self.db_path,
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+        )?;
+        conn.busy_timeout(Duration::from_secs(2))?;
+        Ok(conn)
+    }
+
+    /// Recent/unfinished session rows; empty on any error, never an error.
+    ///
+    /// `since` is epoch seconds; OpenCode stores epoch milliseconds, so
+    /// the bound is scaled up on the way in and row times scaled down on
+    /// the way out.
+    pub fn sessions(&mut self, since: f64) -> Vec<SessionMeta> {
+        match self.try_sessions(since) {
+            Ok(rows) => rows,
+            Err(_) => {
+                self.warn();
+                Vec::new()
+            }
+        }
+    }
+
+    fn try_sessions(&self, since: f64) -> rusqlite::Result<Vec<SessionMeta>> {
+        let conn = self.connect()?;
+        let mut stmt = conn.prepare(
+            "SELECT s.id, s.title, s.model, s.cost,
+                    s.tokens_input, s.tokens_output,
+                    s.tokens_cache_read, s.tokens_cache_write,
+                    s.time_created, s.time_updated, s.time_archived,
+                    (SELECT data FROM message m WHERE m.session_id = s.id
+                     ORDER BY m.rowid DESC LIMIT 1)
+             FROM session s
+             WHERE s.time_created >= ?1 OR s.time_archived IS NULL",
+        )?;
+        let rows = stmt.query_map([since * 1000.0], |row| {
+            let last_msg: Option<String> = row.get(11)?;
+            let (role, finish) = role_finish(last_msg.as_deref());
+            let role = role.as_deref();
+            let finish = finish.as_deref();
+            let created = nonzero(row.get(8)?);
+            let updated = nonzero(row.get(9)?);
+            Ok(SessionMeta {
+                id: row.get(0)?,
+                started_at: created.unwrap_or(0.0) / 1000.0,
+                ended: row.get::<_, Option<i64>>(10)?.is_some(),
+                model: model_id(row.get::<_, Option<String>>(2)?.as_deref()),
+                title: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+                in_tok: tok(row.get(4)?) + tok(row.get(6)?) + tok(row.get(7)?),
+                out_tok: tok(row.get(5)?),
+                cost: row.get::<_, Option<f64>>(3)?.unwrap_or(0.0),
+                last_ts: updated.or(created).unwrap_or(0.0) / 1000.0,
+                turn_done: role == Some("assistant") && finish == Some("stop"),
+                tool_pending: role == Some("assistant") && finish == Some("tool-calls"),
+                last_tool: "-".to_string(),
+                last_line: last_line(role, finish),
+                last_event: None,
+            })
+        })?;
+        rows.collect()
+    }
+
+    /// Name of the most recent tool-type part; a bounded scan since parts
+    /// interleave text/reasoning/tool rows (no JSON1 dependency). "-" on
+    /// any error or when none of the last 20 parts is a tool call.
+    pub fn last_tool(&self, session_id: &str) -> String {
+        self.try_last_tool(session_id)
+            .unwrap_or_else(|_| "-".to_string())
+    }
+
+    fn try_last_tool(&self, session_id: &str) -> rusqlite::Result<String> {
+        let conn = self.connect()?;
+        let mut stmt = conn
+            .prepare("SELECT data FROM part WHERE session_id = ?1 ORDER BY rowid DESC LIMIT 20")?;
+        let rows = stmt.query_map([session_id], |row| row.get::<_, String>(0))?;
+        for data in rows {
+            let Ok(v) = serde_json::from_str::<Value>(&data?) else {
+                continue;
+            };
+            if v.get("type").and_then(Value::as_str) == Some("tool") {
+                let tool = v.get("tool").and_then(Value::as_str).unwrap_or("-");
+                return Ok(tool.to_string());
+            }
+        }
+        Ok("-".to_string())
+    }
+
+    fn warn(&mut self) {
+        if !self.warned {
+            self.warned = true;
+            eprintln!("· opencode db unavailable: {}", self.db_path.display());
+        }
+    }
+}
+
+fn expand_user(p: &Path) -> PathBuf {
+    if let Ok(rest) = p.strip_prefix("~")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    p.to_path_buf()
+}
+
+/// Python `or` semantics: a zero timestamp falls through to the fallback.
+fn nonzero(v: Option<f64>) -> Option<f64> {
+    v.filter(|&x| x != 0.0)
+}
+
+fn tok(v: Option<i64>) -> u64 {
+    v.unwrap_or(0).max(0) as u64
+}
+
+fn model_id(raw: Option<&str>) -> String {
+    raw.and_then(|s| serde_json::from_str::<Value>(s).ok())
+        .and_then(|v| v.get("id").and_then(Value::as_str).map(str::to_string))
+        .unwrap_or_else(|| "?".to_string())
+}
+
+fn role_finish(data: Option<&str>) -> (Option<String>, Option<String>) {
+    let Some(v) = data.and_then(|s| serde_json::from_str::<Value>(s).ok()) else {
+        return (None, None);
+    };
+    (
+        v.get("role").and_then(Value::as_str).map(str::to_string),
+        v.get("finish").and_then(Value::as_str).map(str::to_string),
+    )
+}
+
+/// One-line summary of the most recent message. OpenCode's `message.data`
+/// blob carries turn state, not text (the text lives in `part` rows), so
+/// the summary is the turn state itself, e.g. "assistant · tool-calls".
+fn last_line(role: Option<&str>, finish: Option<&str>) -> String {
+    match (role, finish) {
+        (Some(r), Some(f)) => format!("{r} · {f}"),
+        (Some(r), None) => r.to_string(),
+        _ => String::new(),
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,6 @@
 //! Terminal UI widgets built on ratatui.
 
 pub mod list;
-pub mod pane;
 pub mod palette;
+pub mod pane;
 pub mod roster;

--- a/tests/opencode_source.rs
+++ b/tests/opencode_source.rs
@@ -1,0 +1,346 @@
+//! OpenCodeSource tests against a fixture DB built from the captured
+//! schema, mirroring `tests/test_opencode.py` `TestOpenCodeSource`.
+//! Times in the fixture are epoch milliseconds, matching the real schema.
+
+mod common;
+
+use std::path::PathBuf;
+
+use rusqlite::{Connection, params};
+use tempfile::TempDir;
+
+use common::{fixture_path, temp_db_from_schema};
+use hermon::source::opencode::OpenCodeSource;
+use hermon::source::{Liveness, classify};
+
+const NOW: f64 = 1_700_000_000.0;
+const NOW_MS: i64 = 1_700_000_000_000;
+const IDLE: f64 = 180.0;
+const FRESH: f64 = 3_600.0;
+const MODEL_JSON: &str = r#"{"id":"claude-sonnet-5","providerID":"github-copilot"}"#;
+
+fn open_fixture() -> (TempDir, PathBuf, Connection) {
+    let (dir, db_path) = temp_db_from_schema(&fixture_path("opencode_schema.sql"));
+    let conn = Connection::open(&db_path).expect("open writable setup connection");
+    // the fixture deliberately omits tables like `project` that the kept
+    // tables reference, so FK checks must be off for setup inserts
+    conn.pragma_update(None, "foreign_keys", false)
+        .expect("disable foreign keys");
+    (dir, db_path, conn)
+}
+
+fn insert_session(
+    conn: &Connection,
+    id: &str,
+    model: &str,
+    created_ms: i64,
+    updated_ms: i64,
+    archived_ms: Option<i64>,
+) {
+    conn.execute(
+        "INSERT INTO session (id, project_id, slug, directory, title, version, model,
+         cost, tokens_input, tokens_output, tokens_cache_read, tokens_cache_write,
+         time_created, time_updated, time_archived)
+         VALUES (?1, 'prj', ?1, '/tmp', 'Live One', '1', ?2, 0.05, 100, 20, 50, 5,
+                 ?3, ?4, ?5)",
+        params![id, model, created_ms, updated_ms, archived_ms],
+    )
+    .expect("insert session");
+}
+
+fn insert_message(conn: &Connection, id: &str, session_id: &str, ts_ms: i64, data: &str) {
+    conn.execute(
+        "INSERT INTO message (id, session_id, time_created, time_updated, data)
+         VALUES (?1, ?2, ?3, ?3, ?4)",
+        params![id, session_id, ts_ms, data],
+    )
+    .expect("insert message");
+}
+
+fn insert_part(conn: &Connection, id: &str, session_id: &str, ts_ms: i64, data: &str) {
+    conn.execute(
+        "INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+         VALUES (?1, 'msg_1', ?2, ?3, ?3, ?4)",
+        params![id, session_id, ts_ms, data],
+    )
+    .expect("insert part");
+}
+
+fn msg(role: &str, finish: Option<&str>) -> String {
+    match finish {
+        Some(f) => format!(r#"{{"role":"{role}","finish":"{f}"}}"#),
+        None => format!(r#"{{"role":"{role}"}}"#),
+    }
+}
+
+/// One live session with a pending tool call, as in the Python fixture.
+fn live_fixture() -> (TempDir, PathBuf) {
+    let (dir, db_path, conn) = open_fixture();
+    insert_session(
+        &conn,
+        "ses_live01",
+        MODEL_JSON,
+        NOW_MS - 120_000,
+        NOW_MS - 5_000,
+        None,
+    );
+    insert_message(
+        &conn,
+        "msg_1",
+        "ses_live01",
+        NOW_MS - 5_000,
+        &msg("assistant", Some("tool-calls")),
+    );
+    (dir, db_path)
+}
+
+#[test]
+fn live_tool_pending_session_meta() {
+    let (_dir, db_path) = live_fixture();
+    let mut src = OpenCodeSource::new(&db_path);
+    let rows = src.sessions(NOW - 3_600.0);
+    assert_eq!(rows.len(), 1);
+    let s = &rows[0];
+    assert_eq!(s.id, "ses_live01");
+    assert_eq!(s.model, "claude-sonnet-5");
+    assert_eq!(s.title, "Live One");
+    assert_eq!(s.in_tok, 155); // input + cache_read + cache_write
+    assert_eq!(s.out_tok, 20);
+    assert!((s.cost - 0.05).abs() < 1e-9);
+    assert!(s.tool_pending);
+    assert!(!s.turn_done);
+    assert!(!s.ended);
+    assert_eq!(s.last_tool, "-");
+    assert_eq!(s.last_line, "assistant · tool-calls");
+    assert!(s.last_event.is_none());
+    // tool-calls pending -> live even though 5s of silence have passed
+    assert_eq!(classify(s, NOW, IDLE, FRESH), Liveness::Live);
+}
+
+#[test]
+fn clean_stop_is_turn_done() {
+    let (_dir, db_path, conn) = open_fixture();
+    insert_session(
+        &conn,
+        "ses_done01",
+        MODEL_JSON,
+        NOW_MS - 120_000,
+        NOW_MS - 5_000,
+        None,
+    );
+    insert_message(
+        &conn,
+        "msg_1",
+        "ses_done01",
+        NOW_MS - 5_000,
+        &msg("assistant", Some("stop")),
+    );
+
+    let mut src = OpenCodeSource::new(&db_path);
+    let s = &src.sessions(NOW - 3_600.0)[0];
+    assert!(s.turn_done);
+    assert!(!s.tool_pending);
+    assert_eq!(s.last_line, "assistant · stop");
+    // done the instant the turn closes, regardless of recency
+    assert_eq!(classify(s, NOW, IDLE, FRESH), Liveness::Done);
+}
+
+#[test]
+fn archived_session_is_ended() {
+    let (_dir, db_path, conn) = open_fixture();
+    insert_session(
+        &conn,
+        "ses_arch01",
+        MODEL_JSON,
+        NOW_MS - 120_000,
+        NOW_MS - 5_000,
+        Some(NOW_MS - 1_000),
+    );
+    insert_message(
+        &conn,
+        "msg_1",
+        "ses_arch01",
+        NOW_MS - 5_000,
+        &msg("assistant", Some("tool-calls")),
+    );
+
+    let mut src = OpenCodeSource::new(&db_path);
+    let s = &src.sessions(NOW - 3_600.0)[0];
+    assert!(s.ended);
+    // ended wins over the pending tool call
+    assert_eq!(classify(s, NOW, IDLE, FRESH), Liveness::Done);
+}
+
+#[test]
+fn timestamps_convert_ms_to_seconds() {
+    let (_dir, db_path) = live_fixture();
+    let mut src = OpenCodeSource::new(&db_path);
+    let s = &src.sessions(NOW - 3_600.0)[0];
+    // stored as epoch milliseconds, surfaced as epoch seconds
+    assert_eq!(s.started_at, NOW - 120.0);
+    assert_eq!(s.last_ts, NOW - 5.0);
+}
+
+#[test]
+fn since_bound_is_scaled_to_milliseconds() {
+    let (_dir, db_path, conn) = open_fixture();
+    // archived, so it only appears when time_created >= since * 1000
+    let created_ms = 2_000_000_000; // epoch 2_000_000 seconds
+    insert_session(
+        &conn,
+        "ses_old",
+        MODEL_JSON,
+        created_ms,
+        created_ms,
+        Some(created_ms),
+    );
+
+    let mut src = OpenCodeSource::new(&db_path);
+    assert_eq!(src.sessions(1_000_000.0).len(), 1);
+    // an unscaled bound (3_000_000 ms) would wrongly include the row
+    assert!(src.sessions(3_000_000.0).is_empty());
+}
+
+#[test]
+fn session_without_messages_has_no_turn_flags() {
+    let (_dir, db_path, conn) = open_fixture();
+    insert_session(
+        &conn,
+        "ses_empty",
+        MODEL_JSON,
+        NOW_MS - 120_000,
+        NOW_MS - 5_000,
+        None,
+    );
+
+    let mut src = OpenCodeSource::new(&db_path);
+    let s = &src.sessions(NOW - 3_600.0)[0];
+    assert!(!s.turn_done);
+    assert!(!s.tool_pending);
+    assert_eq!(s.last_line, "");
+    assert_eq!(s.last_ts, NOW - 5.0);
+}
+
+#[test]
+fn newest_message_row_decides_turn_state() {
+    let (_dir, db_path, conn) = open_fixture();
+    insert_session(
+        &conn,
+        "ses_mid",
+        MODEL_JSON,
+        NOW_MS - 120_000,
+        NOW_MS - 5_000,
+        None,
+    );
+    insert_message(
+        &conn,
+        "msg_1",
+        "ses_mid",
+        NOW_MS - 10_000,
+        &msg("assistant", Some("stop")),
+    );
+    insert_message(
+        &conn,
+        "msg_2",
+        "ses_mid",
+        NOW_MS - 5_000,
+        &msg("user", None),
+    );
+
+    let mut src = OpenCodeSource::new(&db_path);
+    let s = &src.sessions(NOW - 3_600.0)[0];
+    // the unanswered user message, not the earlier clean stop, is current
+    assert!(!s.turn_done);
+    assert!(!s.tool_pending);
+    assert_eq!(s.last_line, "user");
+    assert_eq!(classify(s, NOW, IDLE, FRESH), Liveness::Live);
+}
+
+#[test]
+fn malformed_json_is_tolerated() {
+    let (_dir, db_path, conn) = open_fixture();
+    insert_session(
+        &conn,
+        "ses_bad",
+        "not json",
+        NOW_MS - 120_000,
+        NOW_MS - 5_000,
+        None,
+    );
+    insert_message(&conn, "msg_1", "ses_bad", NOW_MS - 5_000, "{not json");
+
+    let mut src = OpenCodeSource::new(&db_path);
+    let s = &src.sessions(NOW - 3_600.0)[0];
+    assert_eq!(s.model, "?");
+    assert!(!s.turn_done);
+    assert!(!s.tool_pending);
+    assert_eq!(s.last_line, "");
+}
+
+#[test]
+fn missing_db_returns_empty() {
+    let mut src = OpenCodeSource::new("/nonexistent/dir/opencode.db");
+    assert!(src.sessions(0.0).is_empty());
+    assert_eq!(src.last_tool("ses_x"), "-");
+}
+
+#[test]
+fn last_tool_scans_recent_parts() {
+    let (_dir, db_path) = live_fixture();
+    let conn = Connection::open(&db_path).expect("reopen writable");
+    insert_part(
+        &conn,
+        "prt_1",
+        "ses_live01",
+        NOW_MS - 4_000,
+        r#"{"type":"text","text":"thinking"}"#,
+    );
+    insert_part(
+        &conn,
+        "prt_2",
+        "ses_live01",
+        NOW_MS - 3_000,
+        r#"{"type":"tool","tool":"bash","state":{"status":"completed"}}"#,
+    );
+
+    let src = OpenCodeSource::new(&db_path);
+    assert_eq!(src.last_tool("ses_live01"), "bash");
+    assert_eq!(src.last_tool("nope"), "-");
+}
+
+#[test]
+fn last_tool_scan_is_bounded_to_20_rows() {
+    let (_dir, db_path) = live_fixture();
+    let conn = Connection::open(&db_path).expect("reopen writable");
+    insert_part(
+        &conn,
+        "prt_tool",
+        "ses_live01",
+        NOW_MS - 30_000,
+        r#"{"type":"tool","tool":"bash","state":{"status":"completed"}}"#,
+    );
+    for i in 0..20 {
+        insert_part(
+            &conn,
+            &format!("prt_{i}"),
+            "ses_live01",
+            NOW_MS - 20_000 + i,
+            r#"{"type":"text","text":"chatter"}"#,
+        );
+    }
+
+    let src = OpenCodeSource::new(&db_path);
+    // the tool part is the 21st-newest row, past the bounded scan
+    assert_eq!(src.last_tool("ses_live01"), "-");
+}
+
+/// OpenCode-derived `SessionMeta` feeds the exact same classifier as
+/// Hermes, mirroring `tests/test_opencode.py:263`
+/// `test_shares_turn_liveness_with_hermes`.
+#[test]
+fn shares_turn_liveness_with_hermes() {
+    let (_dir, db_path) = live_fixture();
+    let mut src = OpenCodeSource::new(&db_path);
+    let s = &src.sessions(NOW - 3_600.0)[0];
+    assert_eq!(classify(s, NOW, IDLE, FRESH), Liveness::Live);
+}

--- a/tests/schema_fixtures.rs
+++ b/tests/schema_fixtures.rs
@@ -23,8 +23,14 @@ fn hermes_schema_builds_with_expected_tables() {
     let conn = Connection::open(&db_path).expect("reopen temp db");
 
     let tables = table_names(&conn);
-    assert!(tables.contains(&"sessions".to_string()), "tables: {tables:?}");
-    assert!(tables.contains(&"messages".to_string()), "tables: {tables:?}");
+    assert!(
+        tables.contains(&"sessions".to_string()),
+        "tables: {tables:?}"
+    );
+    assert!(
+        tables.contains(&"messages".to_string()),
+        "tables: {tables:?}"
+    );
 }
 
 #[test]
@@ -33,7 +39,13 @@ fn opencode_schema_builds_with_expected_tables() {
     let conn = Connection::open(&db_path).expect("reopen temp db");
 
     let tables = table_names(&conn);
-    assert!(tables.contains(&"session".to_string()), "tables: {tables:?}");
-    assert!(tables.contains(&"message".to_string()), "tables: {tables:?}");
+    assert!(
+        tables.contains(&"session".to_string()),
+        "tables: {tables:?}"
+    );
+    assert!(
+        tables.contains(&"message".to_string()),
+        "tables: {tables:?}"
+    );
     assert!(tables.contains(&"part".to_string()), "tables: {tables:?}");
 }


### PR DESCRIPTION
Closes #8.

Implemented by delegated agent; independently verified locally: cargo build, cargo test, cargo clippy --all-targets all green.

See issue for spec; port follows hermon.py line references cited there.