### PR TITLE
Engine thread, channels and Event types

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,1 +1,19 @@
 //! Runtime configuration derived from CLI flags.
+
+use std::time::Duration;
+
+/// Everything [`crate::engine::Engine`] needs to scan sources and pace its
+/// loop: the same store locations `Sources::new` takes, plus the watcher
+/// tuning knobs (`hermon.py:1294 cmd_watch`).
+#[derive(Debug, Clone)]
+pub struct EngineConfig {
+    pub claude_dir: String,
+    pub hermes_db: String,
+    pub opencode_db: String,
+    /// Safety ceiling for a session stuck mid-turn with no activity.
+    pub idle_timeout: f64,
+    /// How long a finished session stays on the roster before aging out.
+    pub fresh_window: f64,
+    /// How often the engine rescans every source.
+    pub interval: Duration,
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,1 +1,199 @@
 //! The watcher loop: polls sources, tracks sessions, drives tmux panes.
+//!
+//! Port of the Python daemon loop's polling half (`hermon.py:1294
+//! cmd_watch`) — the `while True: … time.sleep(args.interval)` body that
+//! rebuilds the roster every tick — minus tmux, restructured as a thread
+//! talking to the UI over two `mpsc` channels rather than driving panes
+//! directly. Pane management (M3) and eviction/linger (M4) are not here yet.
+
+use std::collections::HashMap;
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
+use std::thread::{self, JoinHandle};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use crate::config::EngineConfig;
+use crate::roster::{RosterRow, Sources, build_roster};
+use crate::source::Liveness;
+
+/// Engine → UI. `Roster` is a full replacement of the deck each tick, not a
+/// diff — the UI is expected to redraw from it wholesale.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Event {
+    Roster(Vec<RosterRow>),
+    Lifecycle {
+        key: String,
+        change: Lifecycle,
+    },
+    /// Placeholder for the attention-alert channel landing in M6.
+    Alert,
+}
+
+/// A session's liveness crossing a boundary the UI should narrate, keyed by
+/// [`RosterRow::key`] (`hermon.py:1352` `~/●/✓` log lines).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Lifecycle {
+    /// First tick a session's key was seen.
+    Started,
+    /// Live or needing attention last tick, done this tick.
+    Finished,
+    /// Done last tick, live or needing attention again this tick.
+    Resumed,
+}
+
+/// UI → engine. `Shutdown` is the only command for M2; the rest arrive with
+/// their features (M3 tailing, M5 pane commands).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiCmd {
+    Shutdown,
+}
+
+pub struct Engine;
+
+impl Engine {
+    /// Spawns the poll loop on its own thread. Returns immediately; join the
+    /// handle after sending [`UiCmd::Shutdown`] (or dropping `rx`'s sender)
+    /// to wait for it to exit.
+    pub fn spawn(config: EngineConfig, tx: Sender<Event>, rx: Receiver<UiCmd>) -> JoinHandle<()> {
+        thread::spawn(move || run(config, &tx, &rx))
+    }
+}
+
+fn run(config: EngineConfig, tx: &Sender<Event>, rx: &Receiver<UiCmd>) {
+    let mut sources = Sources::new(&config.claude_dir, &config.hermes_db, &config.opencode_db);
+    let mut prev_liveness: HashMap<String, Liveness> = HashMap::new();
+
+    loop {
+        let now = now_secs();
+        let rows = build_roster(&mut sources, now, config.fresh_window, config.idle_timeout);
+        let liveness = lifecycle_events(&prev_liveness, &rows);
+        prev_liveness = rows.iter().map(|r| (r.key.clone(), r.state)).collect();
+
+        if tx.send(Event::Roster(rows)).is_err() {
+            return; // UI hung up.
+        }
+        for event in liveness {
+            if tx.send(event).is_err() {
+                return;
+            }
+        }
+
+        match rx.recv_timeout(config.interval) {
+            Ok(UiCmd::Shutdown) => return,
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => return,
+        }
+    }
+}
+
+/// Diffs this tick's rows against the last tick's liveness, in roster order,
+/// so the UI's log line order matches the deck.
+fn lifecycle_events(prev: &HashMap<String, Liveness>, rows: &[RosterRow]) -> Vec<Event> {
+    rows.iter()
+        .filter_map(|row| {
+            let change = match prev.get(&row.key) {
+                None => Lifecycle::Started,
+                Some(Liveness::Done) if row.state != Liveness::Done => Lifecycle::Resumed,
+                Some(prev_state)
+                    if *prev_state != Liveness::Done && row.state == Liveness::Done =>
+                {
+                    Lifecycle::Finished
+                }
+                _ => return None,
+            };
+            Some(Event::Lifecycle {
+                key: row.key.clone(),
+                change,
+            })
+        })
+        .collect()
+}
+
+fn now_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0.0, |d| d.as_secs_f64())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::source::Attn;
+
+    fn row(key: &str, state: Liveness) -> RosterRow {
+        RosterRow {
+            key: key.to_string(),
+            state,
+            model: "m".to_string(),
+            last_tool: "-".to_string(),
+            in_tok: 0,
+            out_tok: 0,
+            cost: 0.0,
+            elapsed: None,
+            last_ts: 0.0,
+            title: String::new(),
+        }
+    }
+
+    #[test]
+    fn a_new_key_is_started() {
+        let prev = HashMap::new();
+        let rows = vec![row("C:aaaaaa", Liveness::Live)];
+        assert_eq!(
+            lifecycle_events(&prev, &rows),
+            vec![Event::Lifecycle {
+                key: "C:aaaaaa".to_string(),
+                change: Lifecycle::Started,
+            }]
+        );
+    }
+
+    #[test]
+    fn live_to_done_is_finished() {
+        let prev = HashMap::from([("C:aaaaaa".to_string(), Liveness::Live)]);
+        let rows = vec![row("C:aaaaaa", Liveness::Done)];
+        assert_eq!(
+            lifecycle_events(&prev, &rows),
+            vec![Event::Lifecycle {
+                key: "C:aaaaaa".to_string(),
+                change: Lifecycle::Finished,
+            }]
+        );
+    }
+
+    #[test]
+    fn done_to_live_is_resumed() {
+        let prev = HashMap::from([("C:aaaaaa".to_string(), Liveness::Done)]);
+        let rows = vec![row("C:aaaaaa", Liveness::Live)];
+        assert_eq!(
+            lifecycle_events(&prev, &rows),
+            vec![Event::Lifecycle {
+                key: "C:aaaaaa".to_string(),
+                change: Lifecycle::Resumed,
+            }]
+        );
+    }
+
+    #[test]
+    fn attention_counts_as_live_for_lifecycle() {
+        let prev = HashMap::from([("C:aaaaaa".to_string(), Liveness::Live)]);
+        let rows = vec![row("C:aaaaaa", Liveness::Attention(Attn::Stuck))];
+        assert!(lifecycle_events(&prev, &rows).is_empty());
+
+        let prev = HashMap::from([("C:aaaaaa".to_string(), Liveness::Attention(Attn::PermWait))]);
+        let rows = vec![row("C:aaaaaa", Liveness::Done)];
+        assert_eq!(
+            lifecycle_events(&prev, &rows),
+            vec![Event::Lifecycle {
+                key: "C:aaaaaa".to_string(),
+                change: Lifecycle::Finished,
+            }]
+        );
+    }
+
+    #[test]
+    fn unchanged_liveness_emits_nothing() {
+        let prev = HashMap::from([("C:aaaaaa".to_string(), Liveness::Live)]);
+        let rows = vec![row("C:aaaaaa", Liveness::Live)];
+        assert!(lifecycle_events(&prev, &rows).is_empty());
+    }
+}

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,0 +1,189 @@
+//! Engine acceptance tests: the background poll loop against fixture
+//! stores, using the real wall clock since [`Engine::spawn`] has no
+//! injectable `now` (same trade-off as `tests/roster.rs`'s `ls` binary
+//! tests).
+
+mod common;
+
+use std::sync::mpsc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use rusqlite::Connection;
+
+use common::{fixture_path, temp_db_from_schema};
+use hermon::config::EngineConfig;
+use hermon::engine::{Engine, Event, Lifecycle, UiCmd};
+
+const RECV_TIMEOUT: Duration = Duration::from_secs(2);
+const TICK: Duration = Duration::from_millis(50);
+
+fn wall_clock_now() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock after the epoch")
+        .as_secs_f64()
+}
+
+fn config(hermes_db: &std::path::Path) -> EngineConfig {
+    EngineConfig {
+        claude_dir: "/nonexistent/claude/projects".to_string(),
+        hermes_db: hermes_db.display().to_string(),
+        opencode_db: "/nonexistent/opencode.db".to_string(),
+        idle_timeout: 180.0,
+        fresh_window: 300.0,
+        interval: TICK,
+    }
+}
+
+/// A live Hermes session: a user message with no turn-completion signal yet.
+fn seed_live_session(conn: &Connection, now: f64) {
+    conn.execute(
+        "INSERT INTO sessions (id, source, model, title, started_at, ended_at,
+                                input_tokens, output_tokens)
+         VALUES ('sess_engine1', 'tui', 'claude-sonnet-5', 'Engine test', ?1, NULL, 10, 5)",
+        [now - 60.0],
+    )
+    .expect("insert session");
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp)
+         VALUES ('sess_engine1', 'user', 'go', ?1)",
+        [now - 5.0],
+    )
+    .expect("insert user message");
+}
+
+/// Closes the session's turn: a clean assistant stop with no pending tool
+/// call flips `turn_done`, which `classify` reads as `Liveness::Done`
+/// immediately, no timeout needed (`src/source/mod.rs turn_liveness_raw`).
+fn finish_session(conn: &Connection, now: f64) {
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, finish_reason, timestamp)
+         VALUES ('sess_engine1', 'assistant', 'done', 'stop', ?1)",
+        [now],
+    )
+    .expect("insert closing message");
+}
+
+#[test]
+fn engine_emits_roster_then_a_lifecycle_finished_on_turn_done() {
+    let (_dir, db_path) = temp_db_from_schema(&fixture_path("hermes_schema.sql"));
+    let now = wall_clock_now();
+    {
+        let conn = Connection::open(&db_path).expect("open seeding connection");
+        seed_live_session(&conn, now);
+    }
+
+    let (tx, engine_rx) = mpsc::channel();
+    let (_ui_tx, rx) = mpsc::channel::<UiCmd>();
+    let handle = Engine::spawn(config(&db_path), tx, rx);
+
+    // Roster arrives within a couple of ticks and carries the live session.
+    let mut saw_live = false;
+    for _ in 0..5 {
+        match engine_rx.recv_timeout(RECV_TIMEOUT).expect("roster event") {
+            Event::Roster(rows) => {
+                if let Some(row) = rows.iter().find(|r| r.key == "H:ngine1") {
+                    assert_eq!(row.state, hermon::source::Liveness::Live);
+                    saw_live = true;
+                    break;
+                }
+            }
+            Event::Lifecycle { .. } | Event::Alert => {}
+        }
+    }
+    assert!(saw_live, "engine never reported the live session");
+
+    // Flip turn_done mid-run; the next tick should see the session finish.
+    {
+        let conn = Connection::open(&db_path).expect("open mutation connection");
+        finish_session(&conn, wall_clock_now());
+    }
+
+    let mut finished = false;
+    for _ in 0..40 {
+        match engine_rx
+            .recv_timeout(RECV_TIMEOUT)
+            .expect("event after mutation")
+        {
+            Event::Lifecycle {
+                key,
+                change: Lifecycle::Finished,
+            } if key == "H:ngine1" => {
+                finished = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+    assert!(finished, "no Lifecycle::Finished for the closed session");
+
+    _ui_tx.send(UiCmd::Shutdown).expect("send shutdown");
+    let start = Instant::now();
+    handle.join().expect("engine thread panicked");
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "engine took too long to shut down: {:?}",
+        start.elapsed()
+    );
+}
+
+#[test]
+fn shutdown_joins_promptly_with_no_sessions() {
+    let (tx, engine_rx) = mpsc::channel();
+    let (ui_tx, rx) = mpsc::channel();
+    let handle = Engine::spawn(
+        EngineConfig {
+            claude_dir: "/nonexistent/claude/projects".to_string(),
+            hermes_db: "/nonexistent/state.db".to_string(),
+            opencode_db: "/nonexistent/opencode.db".to_string(),
+            idle_timeout: 180.0,
+            fresh_window: 300.0,
+            interval: TICK,
+        },
+        tx,
+        rx,
+    );
+
+    match engine_rx.recv_timeout(RECV_TIMEOUT).expect("roster event") {
+        Event::Roster(rows) => assert!(rows.is_empty()),
+        other => panic!("expected an empty Roster first, got {other:?}"),
+    }
+
+    ui_tx.send(UiCmd::Shutdown).expect("send shutdown");
+    let start = Instant::now();
+    handle.join().expect("engine thread panicked");
+    assert!(
+        start.elapsed() < Duration::from_secs(1),
+        "shutdown took {:?}, expected well under a tick's timeout slack",
+        start.elapsed()
+    );
+}
+
+/// A UI that hung up (dropped its `Event` receiver) must end the loop via
+/// the failing `tx.send`, without ever sending `UiCmd::Shutdown`.
+#[test]
+fn a_hung_up_ui_ends_the_loop_via_the_failing_send() {
+    let (tx, engine_rx) = mpsc::channel();
+    let (_ui_tx, rx) = mpsc::channel::<UiCmd>();
+    let handle = Engine::spawn(
+        EngineConfig {
+            claude_dir: "/nonexistent/claude/projects".to_string(),
+            hermes_db: "/nonexistent/state.db".to_string(),
+            opencode_db: "/nonexistent/opencode.db".to_string(),
+            idle_timeout: 180.0,
+            fresh_window: 300.0,
+            interval: TICK,
+        },
+        tx,
+        rx,
+    );
+    drop(engine_rx);
+
+    let start = Instant::now();
+    handle.join().expect("engine thread panicked");
+    assert!(
+        start.elapsed() < Duration::from_secs(2),
+        "engine kept running after its event receiver was dropped: {:?}",
+        start.elapsed()
+    );
+}


### PR DESCRIPTION
Closes #18.

EngineConfig (src/config.rs), Event/Lifecycle/UiCmd enums and Engine::spawn (src/engine.rs): std::thread + mpsc loop rebuilding the roster each tick via the existing Sources/build_roster, diffing liveness across ticks for Started/Finished/Resumed, blocking on recv_timeout(interval) so Shutdown lands immediately; UI hangup (send failure) also ends the loop. 3 new integration tests incl. mid-run DB mutation -> Lifecycle::Finished.

Orchestrator-verified: build --locked, test x2 (no flake), clippy -D warnings, fmt --check, 61 Python tests all green.