### PR TITLE
List mode: dense rows, selection, preview, fleet totals

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ pub struct EngineConfig {
     pub claude_dir: String,
     pub hermes_db: String,
     pub opencode_db: String,
+    /// Hermes `agent.log`, scanned each tick for the API-call ticker.
+    pub hermes_log: String,
     /// Safety ceiling for a session stuck mid-turn with no activity.
     pub idle_timeout: f64,
     /// How long a finished session stays on the roster before aging out.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,12 +7,14 @@
 //! directly. Pane management (M3) and eviction/linger (M4) are not here yet.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::thread::{self, JoinHandle};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::config::EngineConfig;
-use crate::roster::{RosterRow, Sources, build_roster};
+use crate::render::StyledLine;
+use crate::roster::{RosterRow, Sources, TICKER_LIMIT, api_call_ticker, build_roster};
 use crate::source::Liveness;
 
 /// Engine → UI. `Roster` is a full replacement of the deck each tick, not a
@@ -20,6 +22,8 @@ use crate::source::Liveness;
 #[derive(Debug, Clone, PartialEq)]
 pub enum Event {
     Roster(Vec<RosterRow>),
+    /// The newest Hermes API calls, refreshed with the roster.
+    Ticker(Vec<StyledLine>),
     Lifecycle {
         key: String,
         change: Lifecycle,
@@ -68,8 +72,13 @@ fn run(config: EngineConfig, tx: &Sender<Event>, rx: &Receiver<UiCmd>) {
         let liveness = lifecycle_events(&prev_liveness, &rows);
         prev_liveness = rows.iter().map(|r| (r.key.clone(), r.state)).collect();
 
+        let ticker = api_call_ticker(Path::new(&config.hermes_log), TICKER_LIMIT);
+
         if tx.send(Event::Roster(rows)).is_err() {
             return; // UI hung up.
+        }
+        if tx.send(Event::Ticker(ticker)).is_err() {
+            return;
         }
         for event in liveness {
             if tx.send(event).is_err() {
@@ -121,10 +130,12 @@ mod tests {
 
     fn row(key: &str, state: Liveness) -> RosterRow {
         RosterRow {
+            id: format!("id-{key}"),
             key: key.to_string(),
             state,
             model: "m".to_string(),
             last_tool: "-".to_string(),
+            last_line: String::new(),
             in_tok: 0,
             out_tok: 0,
             cost: 0.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub fn run() -> anyhow::Result<()> {
                 claude_dir: args.claude_dir,
                 hermes_db: args.hermes_db,
                 opencode_db: args.opencode_db,
+                hermes_log: args.hermes_log,
                 idle_timeout: args.idle_timeout,
                 fresh_window: 300.0,
                 interval: Duration::from_secs_f64(args.interval),

--- a/src/roster.rs
+++ b/src/roster.rs
@@ -24,12 +24,18 @@ use crate::source::{Attn, Liveness, SessionMeta, Source, classify};
 /// One session as the roster displays it (`hermon.py:1025 RosterRow`).
 #[derive(Debug, Clone, PartialEq)]
 pub struct RosterRow {
+    /// The source's own session id, unchanged. The UI keys its selection on
+    /// this so the cursor stays on a session as rows reorder between ticks.
+    pub id: String,
     /// Pane/roster label: `C:0f865f` (Claude), `H:b356d8` (Hermes),
     /// `O:fiiDPP` (OpenCode).
     pub key: String,
     pub state: Liveness,
     pub model: String,
     pub last_tool: String,
+    /// One-line summary of the newest event, as the source rendered it
+    /// ([`SessionMeta::last_line`]) — what the session is doing right now.
+    pub last_line: String,
     pub in_tok: u64,
     pub out_tok: u64,
     /// Reported spend. Python distinguishes "no cost data" (`-`) from a
@@ -110,10 +116,12 @@ fn roster_row(
         return None;
     }
     Some(RosterRow {
+        id: s.id.clone(),
         key: format!("{label_prefix}:{}", short_id(&s.id)),
         state,
         model: s.model.clone(),
         last_tool,
+        last_line: s.last_line.clone(),
         in_tok: s.in_tok,
         out_tok: s.out_tok,
         cost: s.cost,
@@ -257,7 +265,7 @@ fn row_line(r: &RosterRow) -> StyledLine {
 
 /// The fleet at a glance: `N live · N done · Σ $X.XX · Y in`. Sessions
 /// needing attention are counted as live — they are unfinished work.
-fn totals_line(rows: &[RosterRow]) -> StyledLine {
+pub(crate) fn totals_line(rows: &[RosterRow]) -> StyledLine {
     let done = rows.iter().filter(|r| r.state == Liveness::Done).count();
     // fold, not sum(): f64's Sum identity is -0.0, which prints as "$-0.00".
     let cost = rows.iter().fold(0.0, |acc, r| acc + r.cost);
@@ -290,7 +298,7 @@ fn clock(now: f64) -> String {
 }
 
 /// Thousands separators, matching Python's `{:,}` token counts.
-fn commas(n: u64) -> String {
+pub(crate) fn commas(n: u64) -> String {
     let digits = n.to_string();
     let mut out = String::with_capacity(digits.len() + digits.len() / 3);
     for (i, ch) in digits.char_indices() {
@@ -314,10 +322,12 @@ mod tests {
 
     fn row(key: &str, state: Liveness) -> RosterRow {
         RosterRow {
+            id: format!("id-{key}"),
             key: key.to_string(),
             state,
             model: "claude-sonnet-5".to_string(),
             last_tool: "Bash".to_string(),
+            last_line: "▶ Bash ls -la".to_string(),
             in_tok: 1_234_567,
             out_tok: 890,
             cost: 1.5,

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -1,1 +1,451 @@
-//! Scrollable list widget.
+//! List mode: the fleet as one dense row per session, the totals and API
+//! ticker under it, and a preview of the selected session at the bottom.
+//!
+//! A row is `glyph · key · model/elapsed · what it is doing · cost`, with the
+//! summary column absorbing whatever width is left over. Attention states
+//! tint the row, finished sessions go entirely dim.
+//!
+//! [`render_preview`] takes already-rendered [`StyledLine`]s rather than a
+//! [`RosterRow`], so M3 can swap the streaming transcript tail in for
+//! [`preview_lines`] without touching the layout.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Paragraph};
+
+use crate::render::{Seg, Sem, StyledLine, clip, fmt_elapsed};
+use crate::roster::{RosterRow, commas, totals_line};
+use crate::source::{Attn, Liveness};
+use crate::ui::palette;
+use crate::ui::{App, PREVIEW_HEIGHT};
+
+/// Row column widths. The glyph column is two wide because the ASCII
+/// fallback for `⏸` is `||`; the summary column takes the remainder.
+const W_GLYPH: usize = 2;
+const W_KEY: usize = 10;
+const W_META: usize = 26;
+const W_COST: usize = 9;
+
+/// How much of `last_line` and the title the preview keeps — the same
+/// ceiling the renderers use for tool results.
+const PREVIEW_CLIP: usize = 200;
+
+/// Draw the whole list mode into `area`: rows, stats, preview.
+pub fn render(frame: &mut Frame, area: Rect, app: &App) {
+    let stats = stats_lines(app);
+    let [rows_area, stats_area, preview_area] = Layout::vertical([
+        Constraint::Min(1),
+        Constraint::Length(stats.len() as u16),
+        Constraint::Length(PREVIEW_HEIGHT),
+    ])
+    .areas(area);
+
+    render_rows(frame, rows_area, app);
+    frame.render_widget(Paragraph::new(to_lines(&stats)), stats_area);
+
+    let selected = app.selected_row();
+    let title = selected.map_or("—", |r| r.key.as_str());
+    let body = selected.map(preview_lines).unwrap_or_default();
+    render_preview(frame, preview_area, title, &body);
+}
+
+fn render_rows(frame: &mut Frame, area: Rect, app: &App) {
+    if app.roster.is_empty() {
+        frame.render_widget(Paragraph::new(to_lines(&empty_state(&app.paths))), area);
+        return;
+    }
+
+    let selected = app.selected_index();
+    let lines: Vec<Line> = app
+        .roster
+        .iter()
+        .enumerate()
+        .map(|(i, row)| {
+            let line = row_line(row, area.width as usize);
+            if i == selected {
+                line.patch_style(palette::selection_bg())
+            } else {
+                line
+            }
+        })
+        .collect();
+
+    // Scrollback is M3; this only keeps the cursor on screen when the fleet
+    // is taller than the pane.
+    let offset = (selected + 1).saturating_sub(area.height as usize);
+    frame.render_widget(Paragraph::new(lines).scroll((offset as u16, 0)), area);
+}
+
+/// One session as a padded, full-width row. Padding matters: the selected
+/// row's background is only visible where the line has cells.
+fn row_line(row: &RosterRow, width: usize) -> Line<'static> {
+    let (glyph, glyph_style) = palette::glyph_for_liveness(row.state);
+    let sems = row_sems(row.state);
+    let meta = format!("{} · {}", row.model, fmt_elapsed(row.elapsed));
+    let cost = format!("${:.4}", row.cost);
+    let w_summary = width.saturating_sub(W_GLYPH + W_KEY + W_META + W_COST);
+
+    let mut spans = vec![
+        Span::styled(format!("{glyph:<W_GLYPH$}"), glyph_style),
+        Span::styled(
+            format!("{:<W_KEY$}", clip(&row.key, W_KEY - 1)),
+            palette::style(sems.text),
+        ),
+        Span::styled(
+            format!("{:<W_META$}", clip(&meta, W_META - 1)),
+            palette::style(sems.meta),
+        ),
+    ];
+    if w_summary > 0 {
+        spans.push(Span::styled(
+            format!("{:<w_summary$}", clip(&row.last_line, w_summary - 1)),
+            palette::style(sems.text),
+        ));
+    }
+    spans.push(Span::styled(
+        format!("{cost:>W_COST$}"),
+        palette::style(sems.cost),
+    ));
+    Line::from(spans)
+}
+
+/// The colors a row paints with: a session needing attention tints its text
+/// and cost amber or red, a finished one goes dim throughout.
+struct RowSems {
+    text: Sem,
+    meta: Sem,
+    cost: Sem,
+}
+
+fn row_sems(state: Liveness) -> RowSems {
+    match state {
+        Liveness::Live => RowSems {
+            text: Sem::Plain,
+            meta: Sem::Dim,
+            cost: Sem::Stat,
+        },
+        Liveness::Attention(Attn::PermWait) => RowSems {
+            text: Sem::User,
+            meta: Sem::Dim,
+            cost: Sem::User,
+        },
+        Liveness::Attention(Attn::Stuck) => RowSems {
+            text: Sem::Error,
+            meta: Sem::Dim,
+            cost: Sem::Error,
+        },
+        Liveness::Done => RowSems {
+            text: Sem::Dim,
+            meta: Sem::Dim,
+            cost: Sem::Dim,
+        },
+    }
+}
+
+/// Fleet totals, plus the newest API call when the ticker has one.
+fn stats_lines(app: &App) -> Vec<StyledLine> {
+    let mut lines = vec![totals_line(&app.roster)];
+    if let Some(last) = app.ticker.last() {
+        lines.push(StyledLine(vec![Seg::new(
+            Sem::Dim,
+            format!("api: {}", last.to_plain().trim()),
+        )]));
+    }
+    lines
+}
+
+/// What a fresh, sessionless deck says: nothing found, and where it looked.
+fn empty_state(paths: &[String]) -> Vec<StyledLine> {
+    let mut lines = vec![
+        StyledLine(vec![Seg::new(Sem::Dim, "no agent sessions found")]),
+        StyledLine::default(),
+    ];
+    lines.extend(
+        paths
+            .iter()
+            .map(|p| StyledLine(vec![Seg::new(Sem::Dim, format!("  watching {p}"))])),
+    );
+    lines
+}
+
+/// The preview body for a session, from roster data alone. M3 replaces this
+/// with the live transcript tail; [`render_preview`] stays as it is.
+pub fn preview_lines(row: &RosterRow) -> Vec<StyledLine> {
+    let sems = row_sems(row.state);
+    vec![
+        StyledLine(vec![
+            Seg::new(sems.text, state_name(row.state)),
+            Seg::new(Sem::Dim, " · tool "),
+            Seg::new(Sem::Tool, row.last_tool.clone()),
+            Seg::new(Sem::Dim, " · "),
+            Seg::new(Sem::Dim, fmt_elapsed(row.elapsed)),
+        ]),
+        StyledLine(vec![Seg::new(Sem::Dim, clip(&row.title, PREVIEW_CLIP))]),
+        StyledLine(vec![Seg::new(
+            Sem::Plain,
+            clip(&row.last_line, PREVIEW_CLIP),
+        )]),
+        StyledLine(vec![Seg::new(
+            Sem::Stat,
+            format!(
+                "Σ {} in / {} out / ${:.4} [{}]",
+                commas(row.in_tok),
+                commas(row.out_tok),
+                row.cost,
+                row.model
+            ),
+        )]),
+    ]
+}
+
+/// The bordered `preview — <key>` box. Takes rendered lines, not a row, so
+/// the streaming tail can feed it unchanged.
+pub fn render_preview(frame: &mut Frame, area: Rect, key: &str, lines: &[StyledLine]) {
+    let block = Block::bordered()
+        .border_style(palette::border())
+        .title(format!("preview — {key}"));
+    frame.render_widget(Paragraph::new(to_lines(lines)).block(block), area);
+}
+
+fn state_name(state: Liveness) -> &'static str {
+    match state {
+        Liveness::Live => "live",
+        Liveness::Attention(Attn::PermWait) => "waiting on you",
+        Liveness::Attention(Attn::Stuck) => "stuck",
+        Liveness::Done => "done",
+    }
+}
+
+fn to_lines(lines: &[StyledLine]) -> Vec<Line<'static>> {
+    lines.iter().map(palette::line_to_spans).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use ratatui::style::Color;
+
+    use super::*;
+    use crate::render::DIM;
+
+    /// Five sessions covering every liveness state, newest first, as the
+    /// engine would deliver them.
+    fn fixture() -> Vec<RosterRow> {
+        vec![
+            row("C:aaaaaa", Liveness::Live, 1.5),
+            row("H:bbbbbb", Liveness::Attention(Attn::PermWait), 0.25),
+            row("O:cccccc", Liveness::Attention(Attn::Stuck), 0.0),
+            row("C:dddddd", Liveness::Done, 12.0),
+            row("H:eeeeee", Liveness::Live, 0.125),
+        ]
+    }
+
+    fn row(key: &str, state: Liveness, cost: f64) -> RosterRow {
+        RosterRow {
+            id: format!("id-{key}"),
+            key: key.to_string(),
+            state,
+            model: "claude-sonnet-5".to_string(),
+            last_tool: "Bash".to_string(),
+            last_line: format!("▶ Bash working on {key} for a good long while now"),
+            in_tok: 1_234_567,
+            out_tok: 890,
+            cost,
+            elapsed: Some(187.0),
+            last_ts: 0.0,
+            title: "a title".to_string(),
+        }
+    }
+
+    fn app(rows: Vec<RosterRow>) -> App {
+        App {
+            selected_id: rows.first().map(|r| r.id.clone()),
+            roster: rows,
+            ..App::default()
+        }
+    }
+
+    fn draw(app: &App, width: u16, height: u16) -> Buffer {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| render(frame, frame.area(), app))
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    /// The `y`th row of the buffer as plain text.
+    fn text_at(buf: &Buffer, y: u16) -> String {
+        (0..buf.area.width)
+            .map(|x| buf[(x, y)].symbol())
+            .collect::<String>()
+            .trim_end()
+            .to_string()
+    }
+
+    /// The whole frame as text, for the assertions that only care that
+    /// something reached the screen.
+    fn all_text(buf: &Buffer) -> String {
+        (0..buf.area.height)
+            .map(|y| text_at(buf, y))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn every_session_gets_a_row_with_its_glyph_key_and_cost() {
+        let buf = draw(&app(fixture()), 100, 20);
+        let (live, _) = palette::glyph_for_liveness(Liveness::Live);
+        let (wait, _) = palette::glyph_for_liveness(Liveness::Attention(Attn::PermWait));
+        let (stuck, _) = palette::glyph_for_liveness(Liveness::Attention(Attn::Stuck));
+        let (done, _) = palette::glyph_for_liveness(Liveness::Done);
+
+        let rows: Vec<String> = (0..5).map(|y| text_at(&buf, y)).collect();
+        for (i, glyph) in [live, wait, stuck, done, live].iter().enumerate() {
+            assert!(rows[i].starts_with(glyph), "row {i}: {:?}", rows[i]);
+        }
+        assert!(rows[0].contains("C:aaaaaa"), "{:?}", rows[0]);
+        assert!(rows[0].contains("claude-sonnet-5 · 3m07s"), "{:?}", rows[0]);
+        assert!(rows[0].contains("working on C:aaaaaa"), "{:?}", rows[0]);
+        assert!(rows[0].ends_with("$1.5000"), "{:?}", rows[0]);
+        assert!(rows[3].ends_with("$12.0000"), "{:?}", rows[3]);
+    }
+
+    #[test]
+    fn a_done_row_is_dim_from_end_to_end() {
+        let buf = draw(&app(fixture()), 100, 20);
+        let dim = Color::Rgb(DIM.r, DIM.g, DIM.b);
+        // Row 3 is the finished session; every painted cell is dim.
+        for x in 0..buf.area.width {
+            assert_eq!(buf[(x, 3)].fg, dim, "cell {x} of the done row is not dim");
+        }
+        // Its live neighbour is not.
+        assert!((0..buf.area.width).any(|x| buf[(x, 0)].fg != dim));
+    }
+
+    #[test]
+    fn attention_rows_take_their_state_color() {
+        let buf = draw(&app(fixture()), 100, 20);
+        let amber = palette::style(Sem::User).fg.unwrap();
+        let red = palette::style(Sem::Error).fg.unwrap();
+        // The key column of the perm-wait row is amber, the stuck one red.
+        assert_eq!(buf[(W_GLYPH as u16, 1)].fg, amber);
+        assert_eq!(buf[(W_GLYPH as u16, 2)].fg, red);
+    }
+
+    #[test]
+    fn the_selected_row_is_the_only_one_with_the_selection_background() {
+        let mut state = app(fixture());
+        state.selected_id = Some("id-O:cccccc".to_string());
+        let buf = draw(&state, 100, 20);
+        let bg = palette::selection_bg().bg.unwrap();
+
+        for x in 0..buf.area.width {
+            assert_eq!(buf[(x, 2)].bg, bg, "cell {x} of the selected row lacks bg");
+        }
+        for y in [0, 1, 3, 4] {
+            assert!(
+                (0..buf.area.width).all(|x| buf[(x, y)].bg != bg),
+                "row {y} should not be highlighted"
+            );
+        }
+    }
+
+    #[test]
+    fn totals_and_ticker_sit_between_the_list_and_the_preview() {
+        let mut state = app(fixture());
+        state.ticker = vec![StyledLine(vec![Seg::new(
+            Sem::Dim,
+            "  14:23:03 sess03 #  3 claude-sonnet-5@anthropic in=3,000 out=3 1.25s",
+        )])];
+        let buf = draw(&state, 100, 20);
+        let rendered: Vec<String> = (0..20).map(|y| text_at(&buf, y)).collect();
+
+        let totals = rendered
+            .iter()
+            .position(|l| l.contains("live ·"))
+            .expect("totals line");
+        assert_eq!(
+            rendered[totals],
+            "4 live · 1 done · Σ $13.88 · 6,172,835 in"
+        );
+        assert!(rendered[totals + 1].starts_with("api: 14:23:03 sess03"));
+        assert!(
+            rendered[totals + 2].contains("preview — C:aaaaaa"),
+            "{:?}",
+            rendered[totals + 2]
+        );
+    }
+
+    #[test]
+    fn the_preview_shows_the_selected_session_not_the_first() {
+        let mut state = app(fixture());
+        state.selected_id = Some("id-C:dddddd".to_string());
+        let rendered = all_text(&draw(&state, 100, 20));
+
+        assert!(rendered.contains("preview — C:dddddd"), "{rendered}");
+        assert!(rendered.contains("done · tool Bash · 3m07s"), "{rendered}");
+        assert!(rendered.contains("working on C:dddddd"), "{rendered}");
+        assert!(
+            rendered.contains("Σ 1,234,567 in / 890 out / $12.0000 [claude-sonnet-5]"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn a_narrow_frame_truncates_the_summary_instead_of_panicking() {
+        let buf = draw(&app(fixture()), 60, 16);
+        let first = text_at(&buf, 0);
+        assert!(first.contains('…'), "summary not truncated: {first:?}");
+        assert!(first.ends_with("$1.5000"), "{first:?}");
+        assert_eq!(first.chars().count(), 60, "the row should fill the width");
+    }
+
+    #[test]
+    fn very_narrow_and_very_short_frames_still_render() {
+        for (w, h) in [(20u16, 3u16), (12, 1), (1, 1), (40, 2)] {
+            draw(&app(fixture()), w, h);
+        }
+    }
+
+    #[test]
+    fn the_empty_deck_names_the_paths_it_is_watching() {
+        let state = App {
+            paths: vec!["/home/me/.claude/projects".to_string()],
+            ..App::default()
+        };
+        let rendered = all_text(&draw(&state, 60, 12));
+
+        assert!(rendered.contains("no agent sessions found"), "{rendered}");
+        assert!(
+            rendered.contains("watching /home/me/.claude/projects"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("0 live · 0 done · Σ $0.00 · 0 in"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("preview — —"), "{rendered}");
+    }
+
+    #[test]
+    fn the_cursor_scrolls_into_view_on_a_short_pane() {
+        let rows: Vec<RosterRow> = (0..12)
+            .map(|i| row(&format!("C:row{i:03}"), Liveness::Live, 0.0))
+            .collect();
+        let mut state = app(rows);
+        state.selected_id = Some("id-C:row011".to_string());
+        let rendered = all_text(&draw(&state, 80, 10));
+
+        assert!(
+            rendered.contains("C:row011"),
+            "last row scrolled out: {rendered}"
+        );
+        assert!(
+            !rendered.contains("C:row000"),
+            "first row should be scrolled off: {rendered}"
+        );
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! `run_tui` is the app shell for `hermon watch`: raw mode + alternate
 //! screen, a panic hook that restores the terminal before the panic prints,
-//! the engine thread, and the key/redraw loop. The body drawn here is a
-//! placeholder; the real list view is issue #21.
+//! the engine thread, and the key/redraw loop. The body is [`list`], the
+//! only mode there is until grid mode lands.
 
 pub mod list;
 pub mod palette;
@@ -26,12 +26,15 @@ use ratatui::{Frame, Terminal};
 
 use crate::config::EngineConfig;
 use crate::engine::{Engine, Event, UiCmd};
+use crate::render::StyledLine;
 use crate::roster::RosterRow;
 
 const FOOTER: &str = "[q]uit [j/k]select [?]help";
 const HELP: &str = "q / Ctrl-C  quit\nj / \u{2193}       next\nk / \u{2191}       previous\n?           toggle help";
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const REDRAW_INTERVAL: Duration = Duration::from_millis(100);
+/// Preview box: four lines of session detail plus its border.
+const PREVIEW_HEIGHT: u16 = 6;
 
 /// UI state: the latest roster from the engine plus what the user has done
 /// with it. Pure data — every transition is a plain method so tests can
@@ -39,12 +42,29 @@ const REDRAW_INTERVAL: Duration = Duration::from_millis(100);
 #[derive(Debug, Default)]
 pub struct App {
     pub roster: Vec<RosterRow>,
-    pub selected: usize,
+    pub ticker: Vec<StyledLine>,
+    /// The selected session's [`RosterRow::id`], not its row number: the
+    /// roster is re-sorted by activity every tick, so an index would slide
+    /// the cursor onto whichever session happened to overtake it.
+    pub selected_id: Option<String>,
     pub show_help: bool,
     pub quit: bool,
+    /// The store paths the engine is watching, for the empty state.
+    pub paths: Vec<String>,
 }
 
 impl App {
+    fn new(config: &EngineConfig) -> Self {
+        App {
+            paths: vec![
+                config.claude_dir.clone(),
+                config.hermes_db.clone(),
+                config.opencode_db.clone(),
+            ],
+            ..App::default()
+        }
+    }
+
     pub fn handle_key(&mut self, key: KeyEvent) {
         if key.kind != KeyEventKind::Press {
             return;
@@ -64,19 +84,45 @@ impl App {
     pub fn apply_event(&mut self, event: Event) {
         match event {
             Event::Roster(rows) => {
+                // Where the cursor sat, in case its session is gone: falling
+                // back to the same position beats jumping to the top.
+                let position = self.selected_index();
                 self.roster = rows;
-                self.selected = self.selected.min(self.roster.len().saturating_sub(1));
+                if self.selected_row().is_none() {
+                    self.select_at(position);
+                }
             }
+            Event::Ticker(lines) => self.ticker = lines,
             Event::Lifecycle { .. } | Event::Alert => {}
         }
     }
 
+    /// The selected session, or `None` while the roster is empty.
+    pub fn selected_row(&self) -> Option<&RosterRow> {
+        let id = self.selected_id.as_ref()?;
+        self.roster.iter().find(|r| &r.id == id)
+    }
+
+    /// Where the selected session currently sits; 0 when it is gone, which
+    /// is also where an untouched cursor starts.
+    pub fn selected_index(&self) -> usize {
+        self.selected_id
+            .as_ref()
+            .and_then(|id| self.roster.iter().position(|r| &r.id == id))
+            .unwrap_or(0)
+    }
+
+    fn select_at(&mut self, position: usize) {
+        let position = position.min(self.roster.len().saturating_sub(1));
+        self.selected_id = self.roster.get(position).map(|r| r.id.clone());
+    }
+
     fn select_next(&mut self) {
-        self.selected = (self.selected + 1).min(self.roster.len().saturating_sub(1));
+        self.select_at(self.selected_index() + 1);
     }
 
     fn select_prev(&mut self) {
-        self.selected = self.selected.saturating_sub(1);
+        self.select_at(self.selected_index().saturating_sub(1));
     }
 }
 
@@ -101,10 +147,11 @@ fn install_panic_hook(restore: fn()) {
 pub fn run_tui(config: EngineConfig) -> anyhow::Result<()> {
     let (event_tx, event_rx) = mpsc::channel();
     let (cmd_tx, cmd_rx) = mpsc::channel();
+    let app = App::new(&config);
     let engine = Engine::spawn(config, event_tx, cmd_rx);
 
     install_panic_hook(restore_terminal);
-    let result = run_terminal(&event_rx);
+    let result = run_terminal(app, &event_rx);
     restore_terminal();
 
     let _ = cmd_tx.send(UiCmd::Shutdown);
@@ -112,7 +159,7 @@ pub fn run_tui(config: EngineConfig) -> anyhow::Result<()> {
     result
 }
 
-fn run_terminal(rx: &Receiver<Event>) -> anyhow::Result<()> {
+fn run_terminal(mut app: App, rx: &Receiver<Event>) -> anyhow::Result<()> {
     enable_raw_mode()?;
     execute!(io::stdout(), EnterAlternateScreen)?;
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
@@ -123,7 +170,6 @@ fn run_terminal(rx: &Receiver<Event>) -> anyhow::Result<()> {
         panic!("HERMON_PANIC_TEST: forced panic to exercise terminal restore");
     }
 
-    let mut app = App::default();
     let mut last_draw = Instant::now();
     terminal.draw(|frame| draw(frame, &app))?;
 
@@ -147,15 +193,12 @@ fn run_terminal(rx: &Receiver<Event>) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Placeholder frame until the list view lands (#21): session count, footer,
-/// and the help overlay.
+/// A frame: the list view over a one-line footer, with the help overlay on
+/// top when it is open.
 pub fn draw(frame: &mut Frame, app: &App) {
     let [body, footer] =
         Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.area());
-    frame.render_widget(
-        Paragraph::new(format!("{} sessions", app.roster.len())),
-        body,
-    );
+    list::render(frame, body, app);
     frame.render_widget(Paragraph::new(FOOTER), footer);
 
     if app.show_help {
@@ -192,10 +235,12 @@ mod tests {
 
     fn row(key: &str) -> RosterRow {
         RosterRow {
+            id: format!("id-{key}"),
             key: key.to_string(),
             state: Liveness::Live,
             model: "m".to_string(),
             last_tool: "-".to_string(),
+            last_line: String::new(),
             in_tok: 0,
             out_tok: 0,
             cost: 0.0,
@@ -203,6 +248,11 @@ mod tests {
             last_ts: 0.0,
             title: String::new(),
         }
+    }
+
+    /// The selected session's key, which is what the user actually tracks.
+    fn selected_key(app: &App) -> Option<&str> {
+        app.selected_row().map(|r| r.key.as_str())
     }
 
     #[test]
@@ -239,27 +289,55 @@ mod tests {
     fn selection_is_bounded_by_roster_length() {
         let mut app = App::default();
         app.apply_event(Event::Roster(vec![row("a"), row("b"), row("c")]));
+        assert_eq!(selected_key(&app), Some("a"), "first row starts selected");
 
         app.handle_key(key(KeyCode::Char('j')));
         app.handle_key(key(KeyCode::Down));
-        assert_eq!(app.selected, 2);
+        assert_eq!(selected_key(&app), Some("c"));
         app.handle_key(key(KeyCode::Char('j')));
-        assert_eq!(app.selected, 2);
+        assert_eq!(selected_key(&app), Some("c"));
 
         app.handle_key(key(KeyCode::Char('k')));
         app.handle_key(key(KeyCode::Up));
-        assert_eq!(app.selected, 0);
+        assert_eq!(selected_key(&app), Some("a"));
         app.handle_key(key(KeyCode::Char('k')));
-        assert_eq!(app.selected, 0);
+        assert_eq!(selected_key(&app), Some("a"));
     }
 
     #[test]
-    fn selection_stays_zero_on_empty_roster() {
+    fn selection_stays_empty_on_empty_roster() {
         let mut app = App::default();
         app.handle_key(key(KeyCode::Char('j')));
-        assert_eq!(app.selected, 0);
+        assert_eq!(selected_key(&app), None);
         app.handle_key(key(KeyCode::Char('k')));
-        assert_eq!(app.selected, 0);
+        assert_eq!(selected_key(&app), None);
+        assert_eq!(app.selected_index(), 0);
+    }
+
+    /// The roster is re-sorted by activity every tick, so the cursor has to
+    /// follow its session rather than its row number.
+    #[test]
+    fn selection_follows_its_session_across_a_reorder() {
+        let mut app = App::default();
+        app.apply_event(Event::Roster(vec![row("a"), row("b"), row("c")]));
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(selected_key(&app), Some("b"));
+        assert_eq!(app.selected_index(), 1);
+
+        app.apply_event(Event::Roster(vec![row("c"), row("a"), row("b")]));
+        assert_eq!(selected_key(&app), Some("b"));
+        assert_eq!(app.selected_index(), 2);
+    }
+
+    #[test]
+    fn a_vanished_session_leaves_the_cursor_at_its_old_position() {
+        let mut app = App::default();
+        app.apply_event(Event::Roster(vec![row("a"), row("b"), row("c")]));
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(selected_key(&app), Some("b"));
+
+        app.apply_event(Event::Roster(vec![row("a"), row("c")]));
+        assert_eq!(selected_key(&app), Some("c"));
     }
 
     #[test]
@@ -268,10 +346,18 @@ mod tests {
         app.apply_event(Event::Roster(vec![row("a"), row("b"), row("c")]));
         app.handle_key(key(KeyCode::Char('j')));
         app.handle_key(key(KeyCode::Char('j')));
-        assert_eq!(app.selected, 2);
+        assert_eq!(selected_key(&app), Some("c"));
 
         app.apply_event(Event::Roster(vec![row("a")]));
-        assert_eq!(app.selected, 0);
+        assert_eq!(selected_key(&app), Some("a"));
+    }
+
+    #[test]
+    fn the_ticker_event_is_kept_for_the_stats_line() {
+        let mut app = App::default();
+        let tick = StyledLine(vec![crate::render::Seg::new(crate::render::Sem::Dim, "t")]);
+        app.apply_event(Event::Ticker(vec![tick.clone()]));
+        assert_eq!(app.ticker, vec![tick]);
     }
 
     static HOOK_CALLS: Mutex<Vec<&'static str>> = Mutex::new(Vec::new());
@@ -294,16 +380,20 @@ mod tests {
     }
 
     #[test]
-    fn draws_empty_state_before_first_roster() {
-        let mut terminal = Terminal::new(TestBackend::new(30, 4)).unwrap();
-        let app = App::default();
+    fn draws_the_empty_state_and_footer_before_the_first_roster() {
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        let app = App {
+            paths: vec!["/tmp/claude".to_string()],
+            ..App::default()
+        };
         terminal.draw(|frame| draw(frame, &app)).unwrap();
-        terminal.backend().assert_buffer_lines([
-            "0 sessions                    ",
-            "                              ",
-            "                              ",
-            "[q]uit [j/k]select [?]help    ",
-        ]);
+        let rendered = format!("{:?}", terminal.backend().buffer());
+        assert!(rendered.contains("no agent sessions found"), "{rendered}");
+        assert!(rendered.contains("watching /tmp/claude"), "{rendered}");
+        assert!(
+            rendered.contains("[q]uit [j/k]select [?]help"),
+            "{rendered}"
+        );
     }
 
     #[test]

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -29,6 +29,7 @@ fn config(hermes_db: &std::path::Path) -> EngineConfig {
         claude_dir: "/nonexistent/claude/projects".to_string(),
         hermes_db: hermes_db.display().to_string(),
         opencode_db: "/nonexistent/opencode.db".to_string(),
+        hermes_log: "/nonexistent/agent.log".to_string(),
         idle_timeout: 180.0,
         fresh_window: 300.0,
         interval: TICK,
@@ -88,7 +89,7 @@ fn engine_emits_roster_then_a_lifecycle_finished_on_turn_done() {
                     break;
                 }
             }
-            Event::Lifecycle { .. } | Event::Alert => {}
+            Event::Ticker(_) | Event::Lifecycle { .. } | Event::Alert => {}
         }
     }
     assert!(saw_live, "engine never reported the live session");
@@ -136,6 +137,7 @@ fn shutdown_joins_promptly_with_no_sessions() {
             claude_dir: "/nonexistent/claude/projects".to_string(),
             hermes_db: "/nonexistent/state.db".to_string(),
             opencode_db: "/nonexistent/opencode.db".to_string(),
+            hermes_log: "/nonexistent/agent.log".to_string(),
             idle_timeout: 180.0,
             fresh_window: 300.0,
             interval: TICK,
@@ -170,6 +172,7 @@ fn a_hung_up_ui_ends_the_loop_via_the_failing_send() {
             claude_dir: "/nonexistent/claude/projects".to_string(),
             hermes_db: "/nonexistent/state.db".to_string(),
             opencode_db: "/nonexistent/opencode.db".to_string(),
+            hermes_log: "/nonexistent/agent.log".to_string(),
             idle_timeout: 180.0,
             fresh_window: 300.0,
             interval: TICK,


### PR DESCRIPTION
Closes #21.

src/ui/list.rs: dense rows (glyph · key · model·elapsed · last_line · cost) styled via palette only; id-keyed selection surviving reorders (positional fallback when the session vanishes); preview panel behind a Vec<StyledLine> seam for M3; totals reusing roster::totals_line; api: ticker; empty state with watched paths; scroll offset keeping the cursor visible.

Also (flagged by agent, necessary): RosterRow gains session id + last_line, EngineConfig.hermes_log + Event::Ticker so the ticker reaches the TUI.

Orchestrator-verified: 127 Rust + 61 Python tests green, clippy -D warnings, fmt, ls regression intact, and a live tmux smoke: TUI rendered the real running fleet (rows, selection, preview, ticker), q exits clean.

Known cosmetic: ASCII fallback '||' glyph butts the key column (fallback path only).