### PR TITLE
Tailer trait, PaneLines fast tick, live preview, hermon render

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,6 +17,25 @@ pub enum Command {
     Watch(SourceArgs),
     /// Print the roster once to stdout (no tmux).
     Ls(LsArgs),
+    /// Stream one session's transcript to stdout until Ctrl-C.
+    Render(RenderArgs),
+}
+
+/// `hermon render C:0f865f`: one session's pane body on stdout, the parity
+/// harness the per-source renderers are diffed against
+/// (`hermon.py:1443`, which takes a file or `--hermes`/`--opencode` id
+/// where this takes the roster key `hermon ls` already prints).
+#[derive(Debug, Args)]
+pub struct RenderArgs {
+    /// Roster key of the session to tail, e.g. `C:0f865f` (see `hermon ls`).
+    pub key: String,
+
+    #[command(flatten)]
+    pub source: SourceArgs,
+
+    /// Look this many seconds back for the session named by KEY.
+    #[arg(long, default_value_t = 3600.0)]
+    pub fresh_window: f64,
 }
 
 /// `hermon ls`: the source flags plus its own, wider lookback

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -4,18 +4,24 @@
 //! cmd_watch`) — the `while True: … time.sleep(args.interval)` body that
 //! rebuilds the roster every tick — minus tmux, restructured as a thread
 //! talking to the UI over two `mpsc` channels rather than driving panes
-//! directly. Pane management (M3) and eviction/linger (M4) are not here yet.
+//! directly. Panes are tailed here too, on a faster tick than the scan;
+//! eviction/linger (M4) is not here yet.
 
 use std::collections::HashMap;
 use std::path::Path;
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender};
 use std::thread::{self, JoinHandle};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::config::EngineConfig;
 use crate::render::StyledLine;
 use crate::roster::{RosterRow, Sources, TICKER_LIMIT, api_call_ticker, build_roster};
-use crate::source::Liveness;
+use crate::source::{Liveness, Replay, Tailer};
+
+/// How often open panes are polled for new transcript lines. Far quicker
+/// than the roster scan: a pane should read like a terminal, not like a
+/// dashboard refresh.
+pub const PANE_TICK: Duration = Duration::from_millis(300);
 
 /// Engine → UI. `Roster` is a full replacement of the deck each tick, not a
 /// diff — the UI is expected to redraw from it wholesale.
@@ -27,6 +33,13 @@ pub enum Event {
     Lifecycle {
         key: String,
         change: Lifecycle,
+    },
+    /// Transcript lines that appeared in an open pane since the last fast
+    /// tick — an append, not a replacement, and only ever sent for a pane
+    /// the UI asked for with [`UiCmd::OpenPane`].
+    PaneLines {
+        key: String,
+        lines: Vec<StyledLine>,
     },
     /// Placeholder for the attention-alert channel landing in M6.
     Alert,
@@ -44,11 +57,46 @@ pub enum Lifecycle {
     Resumed,
 }
 
-/// UI → engine. `Shutdown` is the only command for M2; the rest arrive with
-/// their features (M3 tailing, M5 pane commands).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// UI → engine. Pane commands follow the cursor: the UI keeps exactly the
+/// selected session's pane open, and the engine only tails what is open.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UiCmd {
     Shutdown,
+    /// Start tailing this [`RosterRow::key`]; its lines arrive as
+    /// [`Event::PaneLines`]. Opening an already-open pane does nothing.
+    OpenPane(String),
+    /// Stop tailing it. The engine drops the tailer, so a later
+    /// [`UiCmd::OpenPane`] replays history again from scratch.
+    ClosePane(String),
+}
+
+/// What the loop needs from the stores: the deck on each scan tick, and a
+/// tailer per pane the UI opens. [`Sources`] is the production
+/// implementation; tests substitute a fake so the loop can be driven with
+/// no real store on disk.
+pub trait Deck {
+    fn roster(&mut self, now: f64, fresh_window: f64, idle_timeout: f64) -> Vec<RosterRow>;
+    fn open_tailer(
+        &mut self,
+        key: &str,
+        session_id: &str,
+        replay: Replay,
+    ) -> Option<Box<dyn Tailer>>;
+}
+
+impl Deck for Sources {
+    fn roster(&mut self, now: f64, fresh_window: f64, idle_timeout: f64) -> Vec<RosterRow> {
+        build_roster(self, now, fresh_window, idle_timeout)
+    }
+
+    fn open_tailer(
+        &mut self,
+        key: &str,
+        session_id: &str,
+        replay: Replay,
+    ) -> Option<Box<dyn Tailer>> {
+        Sources::open_tailer(self, key, session_id, replay)
+    }
 }
 
 pub struct Engine;
@@ -58,40 +106,126 @@ impl Engine {
     /// handle after sending [`UiCmd::Shutdown`] (or dropping `rx`'s sender)
     /// to wait for it to exit.
     pub fn spawn(config: EngineConfig, tx: Sender<Event>, rx: Receiver<UiCmd>) -> JoinHandle<()> {
-        thread::spawn(move || run(config, &tx, &rx))
+        thread::spawn(move || {
+            let mut deck = Sources::new(&config.claude_dir, &config.hermes_db, &config.opencode_db);
+            run(&config, &mut deck, &tx, &rx);
+        })
+    }
+
+    /// The same loop against a caller-supplied [`Deck`] — the seam tests use
+    /// to drive panes without fixture stores.
+    pub fn spawn_with<D: Deck + Send + 'static>(
+        config: EngineConfig,
+        mut deck: D,
+        tx: Sender<Event>,
+        rx: Receiver<UiCmd>,
+    ) -> JoinHandle<()> {
+        thread::spawn(move || run(&config, &mut deck, &tx, &rx))
     }
 }
 
-fn run(config: EngineConfig, tx: &Sender<Event>, rx: &Receiver<UiCmd>) {
-    let mut sources = Sources::new(&config.claude_dir, &config.hermes_db, &config.opencode_db);
+/// Two cadences on one thread: a slow scan tick rebuilding the roster every
+/// `config.interval`, and a fast [`PANE_TICK`] polling open panes. The
+/// `recv_timeout` wait is cut short to whichever falls due first, so
+/// commands are still handled the moment they arrive.
+fn run(config: &EngineConfig, deck: &mut dyn Deck, tx: &Sender<Event>, rx: &Receiver<UiCmd>) {
     let mut prev_liveness: HashMap<String, Liveness> = HashMap::new();
+    // Full session ids by roster key, refreshed each scan: a key carries
+    // only a shortened id, and opening a tailer needs the real one.
+    let mut ids: HashMap<String, String> = HashMap::new();
+    let mut panes: HashMap<String, Box<dyn Tailer>> = HashMap::new();
+
+    let mut next_scan = Instant::now();
+    let mut next_pane_tick = Instant::now();
 
     loop {
-        let now = now_secs();
-        let rows = build_roster(&mut sources, now, config.fresh_window, config.idle_timeout);
-        let liveness = lifecycle_events(&prev_liveness, &rows);
-        prev_liveness = rows.iter().map(|r| (r.key.clone(), r.state)).collect();
-
-        let ticker = api_call_ticker(Path::new(&config.hermes_log), TICKER_LIMIT);
-
-        if tx.send(Event::Roster(rows)).is_err() {
-            return; // UI hung up.
+        if Instant::now() >= next_scan {
+            if scan(config, deck, tx, &mut prev_liveness, &mut ids).is_err() {
+                return; // UI hung up.
+            }
+            next_scan = Instant::now() + config.interval;
         }
-        if tx.send(Event::Ticker(ticker)).is_err() {
-            return;
-        }
-        for event in liveness {
-            if tx.send(event).is_err() {
+        if Instant::now() >= next_pane_tick {
+            if pump_panes(&mut panes, tx).is_err() {
                 return;
             }
+            next_pane_tick = Instant::now() + PANE_TICK;
         }
 
-        match rx.recv_timeout(config.interval) {
+        let deadline = next_scan.min(next_pane_tick);
+        match rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
             Ok(UiCmd::Shutdown) => return,
+            Ok(UiCmd::OpenPane(key)) => {
+                if let Some(tailer) = open_pane(deck, &panes, &ids, &key) {
+                    panes.insert(key, tailer);
+                    // Replay should hit the screen now, not a tick from now.
+                    next_pane_tick = Instant::now();
+                }
+            }
+            Ok(UiCmd::ClosePane(key)) => {
+                panes.remove(&key);
+            }
             Err(RecvTimeoutError::Timeout) => {}
             Err(RecvTimeoutError::Disconnected) => return,
         }
     }
+}
+
+/// One scan tick: rebuild the deck, send it with its lifecycle changes and
+/// the API ticker. `Err` means the UI dropped its receiver.
+fn scan(
+    config: &EngineConfig,
+    deck: &mut dyn Deck,
+    tx: &Sender<Event>,
+    prev_liveness: &mut HashMap<String, Liveness>,
+    ids: &mut HashMap<String, String>,
+) -> Result<(), ()> {
+    let now = now_secs();
+    let rows = deck.roster(now, config.fresh_window, config.idle_timeout);
+    let liveness = lifecycle_events(prev_liveness, &rows);
+    *prev_liveness = rows.iter().map(|r| (r.key.clone(), r.state)).collect();
+    *ids = rows.iter().map(|r| (r.key.clone(), r.id.clone())).collect();
+
+    let ticker = api_call_ticker(Path::new(&config.hermes_log), TICKER_LIMIT);
+
+    tx.send(Event::Roster(rows)).map_err(|_| ())?;
+    tx.send(Event::Ticker(ticker)).map_err(|_| ())?;
+    for event in liveness {
+        tx.send(event).map_err(|_| ())?;
+    }
+    Ok(())
+}
+
+/// One fast tick: every open pane polled once, silent panes sending
+/// nothing. Closed panes are gone from the map, so they are never polled.
+fn pump_panes(panes: &mut HashMap<String, Box<dyn Tailer>>, tx: &Sender<Event>) -> Result<(), ()> {
+    for (key, tailer) in panes.iter_mut() {
+        let lines = tailer.poll();
+        if lines.is_empty() {
+            continue;
+        }
+        tx.send(Event::PaneLines {
+            key: key.clone(),
+            lines,
+        })
+        .map_err(|_| ())?;
+    }
+    Ok(())
+}
+
+/// A tailer for a newly opened pane, or `None` if the pane is already open,
+/// the key is not on the deck, or the source cannot tail that session.
+fn open_pane(
+    deck: &mut dyn Deck,
+    panes: &HashMap<String, Box<dyn Tailer>>,
+    ids: &HashMap<String, String>,
+    key: &str,
+) -> Option<Box<dyn Tailer>> {
+    if panes.contains_key(key) {
+        return None;
+    }
+    let session_id = ids.get(key)?;
+    deck.open_tailer(key, session_id, Replay::DEFAULT)
 }
 
 /// Diffs this tick's rows against the last tick's liveness, in roster order,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,17 @@ pub mod view;
 
 use std::io::IsTerminal;
 use std::path::Path;
+use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use anyhow::anyhow;
 use clap::Parser;
 
 use cli::{Cli, Command, LsArgs};
 use config::EngineConfig;
-use roster::{Sources, TICKER_LIMIT, api_call_ticker, build_roster, roster_lines};
+use engine::PANE_TICK;
+use roster::{Sources, TICKER_LIMIT, api_call_ticker, build_roster, resolve_key, roster_lines};
+use source::Replay;
 
 pub fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -45,6 +49,37 @@ pub fn run() -> anyhow::Result<()> {
             ls(&args);
             Ok(())
         }
+        Command::Render(args) => render(&args),
+    }
+}
+
+fn now_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0.0, |d| d.as_secs_f64())
+}
+
+/// Tail one session to stdout until Ctrl-C, which kills the process the
+/// ordinary way — nothing here holds the terminal (`hermon.py:1443`).
+///
+/// The roster is built once, only to turn the key into a source and a
+/// session id; from there the tailer is the whole loop.
+fn render(args: &cli::RenderArgs) -> anyhow::Result<()> {
+    let src = &args.source;
+    let mut sources = Sources::new(&src.claude_dir, &src.hermes_db, &src.opencode_db);
+    let now = now_secs();
+
+    let rows = build_roster(&mut sources, now, args.fresh_window, src.idle_timeout);
+    let row = resolve_key(&rows, &args.key)?;
+    let mut tailer = sources
+        .open_tailer(&row.key, &row.id, Replay::DEFAULT)
+        .ok_or_else(|| anyhow!("{}: this source cannot tail sessions yet", row.key))?;
+
+    loop {
+        for line in tailer.poll() {
+            println!("{}", line.to_plain());
+        }
+        thread::sleep(PANE_TICK);
     }
 }
 
@@ -54,9 +89,7 @@ pub fn run() -> anyhow::Result<()> {
 fn ls(args: &LsArgs) {
     let src = &args.source;
     let mut sources = Sources::new(&src.claude_dir, &src.hermes_db, &src.opencode_db);
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map_or(0.0, |d| d.as_secs_f64());
+    let now = now_secs();
 
     let rows = build_roster(&mut sources, now, args.fresh_window, src.idle_timeout);
     let ticker = api_call_ticker(Path::new(&src.hermes_log), TICKER_LIMIT);

--- a/src/roster.rs
+++ b/src/roster.rs
@@ -12,6 +12,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::LazyLock;
 
+use anyhow::anyhow;
 use chrono::{DateTime, Local};
 use regex::Regex;
 
@@ -19,7 +20,7 @@ use crate::render::{Seg, Sem, StyledLine, clip, fmt_elapsed, short_id};
 use crate::source::claude::ClaudeSource;
 use crate::source::hermes::HermesSource;
 use crate::source::opencode::OpenCodeSource;
-use crate::source::{Attn, Liveness, SessionMeta, Source, classify};
+use crate::source::{Attn, Liveness, Replay, SessionMeta, Source, Tailer, classify};
 
 /// One session as the roster displays it (`hermon.py:1025 RosterRow`).
 #[derive(Debug, Clone, PartialEq)]
@@ -63,6 +64,42 @@ impl Sources {
             opencode: OpenCodeSource::new(opencode_db),
         }
     }
+
+    /// Opens a tailer for one roster row, picking the source from the key's
+    /// prefix (`C:`/`H:`/`O:`). Both halves of the row are needed: the key
+    /// says which store to ask, and only [`RosterRow::id`] carries the full
+    /// session id — the key's is shortened for display.
+    ///
+    /// `None` when the prefix is unknown or that source has no tailer for
+    /// the session; callers show session metadata instead.
+    pub fn open_tailer(
+        &self,
+        key: &str,
+        session_id: &str,
+        replay: Replay,
+    ) -> Option<Box<dyn Tailer>> {
+        match key.split_once(':')?.0 {
+            "C" => self.claude.open_tailer(session_id, replay),
+            "H" => self.hermes.open_tailer(session_id, replay),
+            "O" => self.opencode.open_tailer(session_id, replay),
+            _ => None,
+        }
+    }
+}
+
+/// Finds the row a `hermon render KEY` argument names. The error lists the
+/// keys that *are* on the deck, since they change from run to run and a
+/// mistyped one is otherwise a guessing game.
+pub fn resolve_key<'a>(rows: &'a [RosterRow], key: &str) -> anyhow::Result<&'a RosterRow> {
+    if let Some(row) = rows.iter().find(|r| r.key == key) {
+        return Ok(row);
+    }
+    let keys: Vec<&str> = rows.iter().map(|r| r.key.as_str()).collect();
+    Err(if keys.is_empty() {
+        anyhow!("no session {key}: no sessions on the roster right now")
+    } else {
+        anyhow!("no session {key}: valid keys are {}", keys.join(" "))
+    })
 }
 
 /// Every session from every source, newest activity first
@@ -334,6 +371,53 @@ mod tests {
             elapsed: Some(187.0),
             last_ts: NOW,
             title: "a title".to_string(),
+        }
+    }
+
+    #[test]
+    fn resolve_key_finds_the_row_it_names() {
+        let rows = vec![
+            row("C:aaaaaa", Liveness::Live),
+            row("H:bbbbbb", Liveness::Done),
+        ];
+        let found = resolve_key(&rows, "H:bbbbbb").expect("key is on the deck");
+        assert_eq!(found.id, "id-H:bbbbbb");
+    }
+
+    /// A mistyped key is the common case, and the valid ones change every
+    /// run, so the error has to name them.
+    #[test]
+    fn resolve_key_lists_the_valid_keys_when_it_fails() {
+        let rows = vec![
+            row("C:aaaaaa", Liveness::Live),
+            row("H:bbbbbb", Liveness::Done),
+        ];
+        let err = resolve_key(&rows, "bogus")
+            .expect_err("bogus key")
+            .to_string();
+        assert!(err.contains("no session bogus"), "{err}");
+        assert!(err.contains("C:aaaaaa"), "{err}");
+        assert!(err.contains("H:bbbbbb"), "{err}");
+    }
+
+    #[test]
+    fn resolve_key_says_so_when_the_roster_is_empty() {
+        let err = resolve_key(&[], "C:aaaaaa")
+            .expect_err("empty roster")
+            .to_string();
+        assert!(err.contains("no sessions on the roster"), "{err}");
+    }
+
+    /// The prefix picks the store; an unknown one is not a panic.
+    #[test]
+    fn open_tailer_dispatches_on_the_key_prefix() {
+        let sources = Sources::new(
+            "/nonexistent/claude",
+            "/nonexistent/h.db",
+            "/nonexistent/o.db",
+        );
+        for key in ["C:aaaaaa", "H:bbbbbb", "O:cccccc", "Z:dddddd", "nocolon"] {
+            assert!(sources.open_tailer(key, "id", Replay::DEFAULT).is_none());
         }
     }
 

--- a/src/source/claude.rs
+++ b/src/source/claude.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use serde_json::{Map, Value};
 
 use crate::render::{clip, parse_ts};
-use crate::source::{LastEvent, SessionMeta};
+use crate::source::{LastEvent, Replay, SessionMeta, Tailer};
 
 /// Tool arguments are clipped at 120 chars, tool results at 200
 /// (`hermon.py:212`, `hermon.py:243`).
@@ -341,6 +341,14 @@ impl ClaudeSource {
             }
             None => "-".to_string(),
         }
+    }
+
+    /// Inherent twin of [`Source::open_tailer`](super::Source::open_tailer)
+    /// — this source is used by
+    /// concrete type, so the trait's default never applies to it.
+    /// `None` until the Claude transcript tailer lands.
+    pub fn open_tailer(&self, _session_id: &str, _replay: Replay) -> Option<Box<dyn Tailer>> {
+        None
     }
 }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,6 +5,8 @@ pub mod claude;
 pub mod hermes;
 pub mod opencode;
 
+use crate::render::StyledLine;
+
 /// The last event observed in a session's transcript. Only the Claude
 /// source can populate this; DB-backed sources (Hermes, OpenCode) leave
 /// `SessionMeta::last_event` as `None`.
@@ -63,6 +65,67 @@ pub trait Source {
     fn sessions(&mut self) -> Vec<SessionMeta>;
     /// The most recently used tool name in a session, or `"-"` if none.
     fn last_tool(&mut self, session_id: &str) -> String;
+    /// Opens a live tail of one session, seeded with `replay` worth of
+    /// history. `None` means this source cannot tail that session — an
+    /// unknown id, an unavailable store, or a source whose tailer has not
+    /// been written yet — and the caller falls back to session metadata.
+    fn open_tailer(&self, _session_id: &str, _replay: Replay) -> Option<Box<dyn Tailer>> {
+        None
+    }
+}
+
+/// How much history a freshly opened [`Tailer`] replays before it streams
+/// only new events.
+///
+/// Both budgets travel together because the caller opening a pane does not
+/// know which kind of store sits behind a roster key: file-backed sources
+/// (Claude transcripts) honour `bytes` and ignore `rows`, database-backed
+/// ones (Hermes, OpenCode) do the reverse. A source may clamp either budget
+/// to whatever its store makes cheap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Replay {
+    /// Seek back at most this many bytes from the end of a transcript file.
+    pub bytes: u64,
+    /// Replay at most this many of the newest rows (Hermes messages,
+    /// OpenCode parts).
+    pub rows: u32,
+}
+
+impl Replay {
+    /// What the TUI and `hermon render` open panes with — a screenful or
+    /// two of context (`hermon.py:1450`, `--replay-bytes 20480`
+    /// / `--replay-parts 40`).
+    pub const DEFAULT: Replay = Replay {
+        bytes: 20_480,
+        rows: 40,
+    };
+}
+
+impl Default for Replay {
+    fn default() -> Self {
+        Replay::DEFAULT
+    }
+}
+
+/// A live view of one session's transcript, polled on every fast tick of
+/// the engine loop (`hermon.py`'s `cmd_render_*` tail loops, as a value
+/// instead of a process).
+///
+/// Implementations are stateful: [`poll`](Tailer::poll) returns only the
+/// lines that appeared since the previous call, so a caller can append the
+/// result straight onto its pane buffer. The first poll after
+/// [`Source::open_tailer`] returns the replay window.
+///
+/// Polling never fails. A store that is missing, locked, rotated or
+/// truncated emits a dim status line (at most one per condition, not one
+/// per tick) and then keeps returning nothing until it can read again, at
+/// which point it resumes on its own: a pane must never go permanently
+/// blank because a file moved under it.
+///
+/// A tailer is polled on the thread that opened it and is not required to
+/// be `Send`.
+pub trait Tailer {
+    fn poll(&mut self) -> Vec<StyledLine>;
 }
 
 /// A running tool call gets a much longer leash.

--- a/src/source/opencode.rs
+++ b/src/source/opencode.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
 
-use super::SessionMeta;
+use super::{Replay, SessionMeta, Tailer};
 
 pub struct OpenCodeSource {
     db_path: PathBuf,
@@ -118,6 +118,14 @@ impl OpenCodeSource {
             }
         }
         Ok("-".to_string())
+    }
+
+    /// Inherent twin of [`Source::open_tailer`](super::Source::open_tailer)
+    /// — this source is used by concrete type (its `sessions` takes a
+    /// `since` bound the trait has no room for), so the trait's default
+    /// never applies to it. `None` until the OpenCode part tailer lands.
+    pub fn open_tailer(&self, _session_id: &str, _replay: Replay) -> Option<Box<dyn Tailer>> {
+        None
     }
 
     fn warn(&mut self) {

--- a/src/ui/list.rs
+++ b/src/ui/list.rs
@@ -6,8 +6,8 @@
 //! tint the row, finished sessions go entirely dim.
 //!
 //! [`render_preview`] takes already-rendered [`StyledLine`]s rather than a
-//! [`RosterRow`], so M3 can swap the streaming transcript tail in for
-//! [`preview_lines`] without touching the layout.
+//! [`RosterRow`], so [`preview_lines`] can hand it either the pane's live
+//! transcript tail or the metadata fallback without touching the layout.
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Layout, Rect};
@@ -31,6 +31,10 @@ const W_COST: usize = 9;
 /// ceiling the renderers use for tool results.
 const PREVIEW_CLIP: usize = 200;
 
+/// Transcript lines the preview box can show: its height less its border.
+/// Anything older stays in the pane buffer for grid mode's scrollback.
+const PREVIEW_BODY: usize = PREVIEW_HEIGHT as usize - 2;
+
 /// Draw the whole list mode into `area`: rows, stats, preview.
 pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let stats = stats_lines(app);
@@ -46,7 +50,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let selected = app.selected_row();
     let title = selected.map_or("—", |r| r.key.as_str());
-    let body = selected.map(preview_lines).unwrap_or_default();
+    let body = selected
+        .map(|row| preview_lines(app, row))
+        .unwrap_or_default();
     render_preview(frame, preview_area, title, &body);
 }
 
@@ -169,9 +175,23 @@ fn empty_state(paths: &[String]) -> Vec<StyledLine> {
     lines
 }
 
-/// The preview body for a session, from roster data alone. M3 replaces this
-/// with the live transcript tail; [`render_preview`] stays as it is.
-pub fn preview_lines(row: &RosterRow) -> Vec<StyledLine> {
+/// The preview body: the live transcript tail as soon as the session's
+/// pane has produced lines, and roster metadata until then — a pane that
+/// was just opened, or a source whose tailer cannot read its store.
+pub fn preview_lines(app: &App, row: &RosterRow) -> Vec<StyledLine> {
+    match app.panes.get(&row.key) {
+        Some(buffer) if !buffer.is_empty() => buffer
+            .iter()
+            .skip(buffer.len().saturating_sub(PREVIEW_BODY))
+            .cloned()
+            .collect(),
+        _ => meta_lines(row),
+    }
+}
+
+/// What a session looks like before its tail arrives, from roster data
+/// alone.
+fn meta_lines(row: &RosterRow) -> Vec<StyledLine> {
     let sems = row_sems(row.state);
     vec![
         StyledLine(vec![
@@ -392,6 +412,45 @@ mod tests {
             rendered.contains("Σ 1,234,567 in / 890 out / $12.0000 [claude-sonnet-5]"),
             "{rendered}"
         );
+    }
+
+    /// Once the pane is streaming, the preview is the transcript tail — the
+    /// metadata summary it showed while waiting is gone.
+    #[test]
+    fn the_preview_shows_the_buffered_tail_once_the_pane_streams() {
+        let mut state = App::default();
+        state.apply_event(crate::engine::Event::Roster(fixture()));
+        state.apply_event(crate::engine::Event::PaneLines {
+            key: "C:aaaaaa".to_string(),
+            lines: (1..=6)
+                .map(|i| StyledLine(vec![Seg::new(Sem::Plain, format!("transcript line {i}"))]))
+                .collect(),
+        });
+        let rendered = all_text(&draw(&state, 100, 20));
+
+        assert!(rendered.contains("preview — C:aaaaaa"), "{rendered}");
+        // Only the last four fit; the box shows the newest end of the tail.
+        assert!(!rendered.contains("transcript line 2"), "{rendered}");
+        for i in 3..=6 {
+            assert!(
+                rendered.contains(&format!("transcript line {i}")),
+                "{rendered}"
+            );
+        }
+        assert!(
+            !rendered.contains("Σ 1,234,567 in"),
+            "metadata should have given way to the tail: {rendered}"
+        );
+    }
+
+    /// A session whose pane has produced nothing yet — just opened, or a
+    /// source with no tailer — still gets the metadata preview.
+    #[test]
+    fn the_preview_falls_back_to_metadata_with_no_buffered_lines() {
+        let mut state = App::default();
+        state.apply_event(crate::engine::Event::Roster(fixture()));
+        let rendered = all_text(&draw(&state, 100, 20));
+        assert!(rendered.contains("live · tool Bash · 3m07s"), "{rendered}");
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -10,8 +10,9 @@ pub mod palette;
 pub mod pane;
 pub mod roster;
 
+use std::collections::{HashMap, VecDeque};
 use std::io;
-use std::sync::mpsc::{self, Receiver};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::time::{Duration, Instant};
 
 use crossterm::event::{self, Event as CtEvent, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
@@ -35,6 +36,9 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const REDRAW_INTERVAL: Duration = Duration::from_millis(100);
 /// Preview box: four lines of session detail plus its border.
 const PREVIEW_HEIGHT: u16 = 6;
+/// Transcript lines kept for the open pane. Far more than the preview box
+/// shows — the surplus is what grid mode's scrollback will read.
+const PANE_SCROLLBACK: usize = 5_000;
 
 /// UI state: the latest roster from the engine plus what the user has done
 /// with it. Pure data — every transition is a plain method so tests can
@@ -51,6 +55,16 @@ pub struct App {
     pub quit: bool,
     /// The store paths the engine is watching, for the empty state.
     pub paths: Vec<String>,
+    /// Transcript lines for the open pane, oldest first. Only the open pane
+    /// has an entry: closing one drops its buffer, so reopening shows the
+    /// engine's fresh replay instead of it twice.
+    pub panes: HashMap<String, VecDeque<StyledLine>>,
+    /// The key whose tailer the engine currently holds open, which is the
+    /// selected session's — tracked separately so a roster reorder that
+    /// leaves the cursor put does not churn the pane.
+    open_pane: Option<String>,
+    /// Commands the run loop has not yet handed to the engine.
+    cmds: Vec<UiCmd>,
 }
 
 impl App {
@@ -79,6 +93,7 @@ impl App {
             KeyCode::Char('k') | KeyCode::Up => self.select_prev(),
             _ => {}
         }
+        self.sync_pane();
     }
 
     pub fn apply_event(&mut self, event: Event) {
@@ -91,10 +106,49 @@ impl App {
                 if self.selected_row().is_none() {
                     self.select_at(position);
                 }
+                self.sync_pane();
             }
             Event::Ticker(lines) => self.ticker = lines,
+            Event::PaneLines { key, lines } => self.buffer_pane(&key, lines),
             Event::Lifecycle { .. } | Event::Alert => {}
         }
+    }
+
+    /// Appends a fast tick's lines to the open pane's buffer, dropping the
+    /// oldest past [`PANE_SCROLLBACK`]. Lines for any other key are stale —
+    /// in flight when the cursor moved — and discarded.
+    fn buffer_pane(&mut self, key: &str, lines: Vec<StyledLine>) {
+        if self.open_pane.as_deref() != Some(key) {
+            return;
+        }
+        let buffer = self.panes.entry(key.to_string()).or_default();
+        buffer.extend(lines);
+        while buffer.len() > PANE_SCROLLBACK {
+            buffer.pop_front();
+        }
+    }
+
+    /// Keeps the engine tailing exactly the selected session: whenever the
+    /// cursor lands on a different one, the old pane is closed (and its
+    /// buffer dropped) and the new one opened.
+    fn sync_pane(&mut self) {
+        let wanted = self.selected_row().map(|r| r.key.clone());
+        if wanted == self.open_pane {
+            return;
+        }
+        if let Some(old) = self.open_pane.take() {
+            self.panes.remove(&old);
+            self.cmds.push(UiCmd::ClosePane(old));
+        }
+        if let Some(new) = wanted.clone() {
+            self.cmds.push(UiCmd::OpenPane(new));
+        }
+        self.open_pane = wanted;
+    }
+
+    /// Hands the engine everything the last transition asked for.
+    pub fn take_commands(&mut self) -> Vec<UiCmd> {
+        std::mem::take(&mut self.cmds)
     }
 
     /// The selected session, or `None` while the roster is empty.
@@ -151,7 +205,7 @@ pub fn run_tui(config: EngineConfig) -> anyhow::Result<()> {
     let engine = Engine::spawn(config, event_tx, cmd_rx);
 
     install_panic_hook(restore_terminal);
-    let result = run_terminal(app, &event_rx);
+    let result = run_terminal(app, &event_rx, &cmd_tx);
     restore_terminal();
 
     let _ = cmd_tx.send(UiCmd::Shutdown);
@@ -159,7 +213,7 @@ pub fn run_tui(config: EngineConfig) -> anyhow::Result<()> {
     result
 }
 
-fn run_terminal(mut app: App, rx: &Receiver<Event>) -> anyhow::Result<()> {
+fn run_terminal(mut app: App, rx: &Receiver<Event>, cmd_tx: &Sender<UiCmd>) -> anyhow::Result<()> {
     enable_raw_mode()?;
     execute!(io::stdout(), EnterAlternateScreen)?;
     let mut terminal = Terminal::new(CrosstermBackend::new(io::stdout()))?;
@@ -184,6 +238,11 @@ fn run_terminal(mut app: App, rx: &Receiver<Event>) -> anyhow::Result<()> {
         for event in rx.try_iter() {
             app.apply_event(event);
             dirty = true;
+        }
+        // A dead engine is not the UI's problem to report: the failing
+        // `Event` channel ends the loop on its own.
+        for cmd in app.take_commands() {
+            let _ = cmd_tx.send(cmd);
         }
         if dirty || last_draw.elapsed() >= REDRAW_INTERVAL {
             terminal.draw(|frame| draw(frame, &app))?;
@@ -358,6 +417,90 @@ mod tests {
         let tick = StyledLine(vec![crate::render::Seg::new(crate::render::Sem::Dim, "t")]);
         app.apply_event(Event::Ticker(vec![tick.clone()]));
         assert_eq!(app.ticker, vec![tick]);
+    }
+
+    fn pane_line(text: &str) -> StyledLine {
+        StyledLine(vec![crate::render::Seg::new(
+            crate::render::Sem::Plain,
+            text,
+        )])
+    }
+
+    /// The engine only tails what the cursor is on, so every selection move
+    /// closes one pane and opens the next.
+    #[test]
+    fn selection_opens_the_new_pane_and_closes_the_old_one() {
+        let mut app = App::default();
+        app.apply_event(Event::Roster(vec![row("a"), row("b")]));
+        assert_eq!(
+            app.take_commands(),
+            vec![UiCmd::OpenPane("a".to_string())],
+            "the first roster opens the selected session's pane"
+        );
+
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(
+            app.take_commands(),
+            vec![
+                UiCmd::ClosePane("a".to_string()),
+                UiCmd::OpenPane("b".to_string()),
+            ]
+        );
+
+        // A roster that leaves the cursor where it was churns nothing.
+        app.apply_event(Event::Roster(vec![row("b"), row("a")]));
+        assert!(app.take_commands().is_empty());
+    }
+
+    #[test]
+    fn pane_lines_are_buffered_for_the_open_pane_only() {
+        let mut app = App::default();
+        app.apply_event(Event::Roster(vec![row("a"), row("b")]));
+        app.apply_event(Event::PaneLines {
+            key: "a".to_string(),
+            lines: vec![pane_line("one"), pane_line("two")],
+        });
+        app.apply_event(Event::PaneLines {
+            key: "b".to_string(),
+            lines: vec![pane_line("not selected")],
+        });
+
+        let buffered: Vec<String> = app.panes["a"].iter().map(StyledLine::to_plain).collect();
+        assert_eq!(buffered, ["one", "two"]);
+        assert!(!app.panes.contains_key("b"), "stale lines were buffered");
+    }
+
+    /// Moving on drops the buffer: the engine replays history when the pane
+    /// is reopened, and keeping the old tail would show it twice.
+    #[test]
+    fn closing_a_pane_drops_its_buffer() {
+        let mut app = App::default();
+        app.apply_event(Event::Roster(vec![row("a"), row("b")]));
+        app.apply_event(Event::PaneLines {
+            key: "a".to_string(),
+            lines: vec![pane_line("one")],
+        });
+        app.handle_key(key(KeyCode::Char('j')));
+        assert!(app.panes.is_empty());
+    }
+
+    #[test]
+    fn the_pane_buffer_is_capped_and_keeps_the_newest_lines() {
+        let mut app = App::default();
+        app.apply_event(Event::Roster(vec![row("a")]));
+        for chunk in 0..3 {
+            app.apply_event(Event::PaneLines {
+                key: "a".to_string(),
+                lines: (0..2_000)
+                    .map(|i| pane_line(&format!("line {}", chunk * 2_000 + i)))
+                    .collect(),
+            });
+        }
+
+        let buffer = &app.panes["a"];
+        assert_eq!(buffer.len(), PANE_SCROLLBACK);
+        assert_eq!(buffer.front().unwrap().to_plain(), "line 1000");
+        assert_eq!(buffer.back().unwrap().to_plain(), "line 5999");
     }
 
     static HOOK_CALLS: Mutex<Vec<&'static str>> = Mutex::new(Vec::new());

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -5,14 +5,20 @@
 
 mod common;
 
-use std::sync::mpsc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Receiver};
+use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use rusqlite::Connection;
 
 use common::{fixture_path, temp_db_from_schema};
 use hermon::config::EngineConfig;
-use hermon::engine::{Engine, Event, Lifecycle, UiCmd};
+use hermon::engine::{Deck, Engine, Event, Lifecycle, PANE_TICK, UiCmd};
+use hermon::render::{Seg, Sem, StyledLine};
+use hermon::roster::RosterRow;
+use hermon::source::{Liveness, Replay, Tailer};
 
 const RECV_TIMEOUT: Duration = Duration::from_secs(2);
 const TICK: Duration = Duration::from_millis(50);
@@ -89,7 +95,8 @@ fn engine_emits_roster_then_a_lifecycle_finished_on_turn_done() {
                     break;
                 }
             }
-            Event::Ticker(_) | Event::Lifecycle { .. } | Event::Alert => {}
+            Event::Ticker(_) | Event::Lifecycle { .. } | Event::PaneLines { .. } | Event::Alert => {
+            }
         }
     }
     assert!(saw_live, "engine never reported the live session");
@@ -189,4 +196,209 @@ fn a_hung_up_ui_ends_the_loop_via_the_failing_send() {
         "engine kept running after its event receiver was dropped: {:?}",
         start.elapsed()
     );
+}
+
+// ------------------------------------------------------------ pane tailing
+
+const PANE_KEY: &str = "C:aaaaaa";
+const PANE_SESSION_ID: &str = "session-aaaaaa";
+
+/// A tailer that emits one line per poll and counts its polls, so a test
+/// can prove a closed pane really does go quiet.
+struct FakeTailer {
+    polls: Arc<AtomicUsize>,
+}
+
+impl Tailer for FakeTailer {
+    fn poll(&mut self) -> Vec<StyledLine> {
+        let n = self.polls.fetch_add(1, Ordering::SeqCst) + 1;
+        vec![StyledLine(vec![Seg::new(Sem::Plain, format!("line {n}"))])]
+    }
+}
+
+/// One always-live session tailed by [`FakeTailer`] — the pane path with
+/// no store on disk. Every `open_tailer` call is recorded for the test to
+/// check afterwards rather than asserted on the engine thread, where a
+/// panic would only show up as a failed join.
+struct FakeDeck {
+    opens: Arc<Mutex<Vec<(String, String, Replay)>>>,
+    polls: Arc<AtomicUsize>,
+}
+
+impl FakeDeck {
+    fn new() -> Self {
+        FakeDeck {
+            opens: Arc::new(Mutex::new(Vec::new())),
+            polls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
+
+impl Deck for FakeDeck {
+    fn roster(&mut self, now: f64, _fresh_window: f64, _idle_timeout: f64) -> Vec<RosterRow> {
+        vec![RosterRow {
+            id: PANE_SESSION_ID.to_string(),
+            key: PANE_KEY.to_string(),
+            state: Liveness::Live,
+            model: "claude-sonnet-5".to_string(),
+            last_tool: "-".to_string(),
+            last_line: String::new(),
+            in_tok: 0,
+            out_tok: 0,
+            cost: 0.0,
+            elapsed: None,
+            last_ts: now,
+            title: String::new(),
+        }]
+    }
+
+    fn open_tailer(
+        &mut self,
+        key: &str,
+        session_id: &str,
+        replay: Replay,
+    ) -> Option<Box<dyn Tailer>> {
+        self.opens.lock().expect("opens lock").push((
+            key.to_string(),
+            session_id.to_string(),
+            replay,
+        ));
+        Some(Box::new(FakeTailer {
+            polls: self.polls.clone(),
+        }))
+    }
+}
+
+/// Scans slowly on purpose: the pane cadence is what these tests watch, and
+/// a fast scan would bury it in roster events.
+fn pane_config() -> EngineConfig {
+    EngineConfig {
+        claude_dir: "/nonexistent/claude/projects".to_string(),
+        hermes_db: "/nonexistent/state.db".to_string(),
+        opencode_db: "/nonexistent/opencode.db".to_string(),
+        hermes_log: "/nonexistent/agent.log".to_string(),
+        idle_timeout: 180.0,
+        fresh_window: 300.0,
+        interval: Duration::from_millis(500),
+    }
+}
+
+/// The next [`Event::PaneLines`], ignoring the roster traffic around it.
+/// The deadline is many fast ticks wide — this asserts "promptly", not a
+/// tick count.
+fn next_pane_lines(rx: &Receiver<Event>) -> Option<(String, Vec<StyledLine>)> {
+    let deadline = Instant::now() + RECV_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        match rx.recv_timeout(remaining) {
+            Ok(Event::PaneLines { key, lines }) => return Some((key, lines)),
+            Ok(_) => {}
+            Err(_) => return None,
+        }
+    }
+}
+
+#[test]
+fn opening_a_pane_streams_its_tailer_lines() {
+    let deck = FakeDeck::new();
+    let opens = deck.opens.clone();
+    let (tx, ev_rx) = mpsc::channel();
+    let (ui_tx, rx) = mpsc::channel();
+    let handle = Engine::spawn_with(pane_config(), deck, tx, rx);
+
+    ui_tx
+        .send(UiCmd::OpenPane(PANE_KEY.to_string()))
+        .expect("send OpenPane");
+
+    let (key, lines) = next_pane_lines(&ev_rx).expect("no PaneLines after OpenPane");
+    assert_eq!(key, PANE_KEY);
+    assert_eq!(lines[0].to_plain(), "line 1", "the replay poll comes first");
+
+    // The pane keeps streaming on later fast ticks, not just once on open.
+    let (_, lines) = next_pane_lines(&ev_rx).expect("no PaneLines on a later tick");
+    assert_eq!(lines[0].to_plain(), "line 2");
+
+    // Opening is once per pane, with the row's full session id — the key
+    // carries only a shortened one — and the default replay window.
+    assert_eq!(
+        *opens.lock().expect("opens lock"),
+        vec![(
+            PANE_KEY.to_string(),
+            PANE_SESSION_ID.to_string(),
+            Replay::DEFAULT
+        )]
+    );
+
+    ui_tx.send(UiCmd::Shutdown).expect("send shutdown");
+    handle.join().expect("engine thread panicked");
+}
+
+#[test]
+fn a_closed_pane_is_not_polled_again() {
+    let deck = FakeDeck::new();
+    let polls = deck.polls.clone();
+    let (tx, ev_rx) = mpsc::channel();
+    let (ui_tx, rx) = mpsc::channel();
+    let handle = Engine::spawn_with(pane_config(), deck, tx, rx);
+
+    ui_tx
+        .send(UiCmd::OpenPane(PANE_KEY.to_string()))
+        .expect("send OpenPane");
+    next_pane_lines(&ev_rx).expect("no PaneLines after OpenPane");
+
+    ui_tx
+        .send(UiCmd::ClosePane(PANE_KEY.to_string()))
+        .expect("send ClosePane");
+
+    // Let the close settle, drop whatever was already in flight, then take
+    // a reading and prove nothing moves after it.
+    thread::sleep(4 * PANE_TICK);
+    for _ in ev_rx.try_iter() {}
+    let settled = polls.load(Ordering::SeqCst);
+
+    thread::sleep(4 * PANE_TICK);
+    assert_eq!(
+        polls.load(Ordering::SeqCst),
+        settled,
+        "a closed pane is still being polled"
+    );
+    let stray: Vec<Event> = ev_rx.try_iter().collect();
+    assert!(
+        !stray.iter().any(|e| matches!(e, Event::PaneLines { .. })),
+        "lines kept arriving after ClosePane: {stray:?}"
+    );
+
+    ui_tx.send(UiCmd::Shutdown).expect("send shutdown");
+    handle.join().expect("engine thread panicked");
+}
+
+/// A key no session answers to (a pane opened for a session that has since
+/// left the deck) opens nothing at all, rather than tailing the wrong one.
+#[test]
+fn a_key_that_is_not_on_the_deck_opens_nothing() {
+    let deck = FakeDeck::new();
+    let opens = deck.opens.clone();
+    let polls = deck.polls.clone();
+    let (tx, ev_rx) = mpsc::channel();
+    let (ui_tx, rx) = mpsc::channel();
+    let handle = Engine::spawn_with(pane_config(), deck, tx, rx);
+
+    ui_tx
+        .send(UiCmd::OpenPane("Z:nosuch".to_string()))
+        .expect("send OpenPane");
+    thread::sleep(4 * PANE_TICK);
+
+    assert!(opens.lock().expect("opens lock").is_empty());
+    assert_eq!(polls.load(Ordering::SeqCst), 0);
+    let seen: Vec<Event> = ev_rx.try_iter().collect();
+    assert!(
+        !seen.iter().any(|e| matches!(e, Event::PaneLines { .. })),
+        "an unknown key produced pane lines: {seen:?}"
+    );
+
+    ui_tx.send(UiCmd::Shutdown).expect("send shutdown");
+    handle.join().expect("engine thread panicked");
 }


### PR DESCRIPTION
Closes #32.

The M3 streaming seam: Tailer trait + Replay (bytes for files, rows for DBs), Source::open_tailer default-None, Event::PaneLines + UiCmd::Open/ClosePane, two-cadence engine loop (1s scan + 300ms pane tick via nearest-Instant recv_timeout), UI-owned pane lifecycle with 5000-line VecDeque buffers feeding the existing preview seam, and hermon render <key> as the parity harness (bogus key errors listing valid keys). FakeDeck/FakeTailer test seam with poll-counter assertions. 142 tests.

Orchestrator-verified: all 5 gates green locally.