### PR TITLE
Release v0.1.0 prep: profile, CI, brew formula + runbook (#46)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+
+      # A tag whose version doesn't match Cargo.toml would ship a binary whose
+      # `--version` disagrees with the formula's, so fail before releasing.
+      - name: Check tag matches crate version
+        run: |
+          crate=$(cargo metadata --no-deps --format-version 1 |
+            python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')
+          tag=${GITHUB_REF_NAME#v}
+          test "$crate" = "$tag" || {
+            echo "tag $GITHUB_REF_NAME does not match Cargo.toml version $crate"
+            exit 1
+          }
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Test
+        run: cargo test
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Format
+        run: cargo fmt --check
+
+      # Legacy Python tests for hermon.py; drop this step once the Rust port replaces it.
+      - name: Python tests
+        run: python3 -m unittest discover -s tests
+
+      # The profile Homebrew builds with (fat LTO, one codegen unit) — verify it
+      # compiles here rather than in a user's `brew install`.
+      - name: Release build
+        run: cargo build --release --locked
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # No binary artifacts yet: the tap builds from the source tarball GitHub
+      # attaches to every release.
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,12 @@ serde_json = "1.0.151"
 
 [dev-dependencies]
 tempfile = "3.27.0"
+
+# Tuned for the shipped binary: one codegen unit and fat LTO so the whole
+# crate graph is optimized together, symbols stripped since we don't ship
+# debug info. Costs build time (a Homebrew source build pays it once);
+# see packaging/RELEASE_NOTES.md for the measured size/startup numbers.
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,22 @@ Each store path is overridable per subcommand: `--claude-dir`, `--hermes-db`,
 
 ## Install
 
-Not yet packaged — building from source with `cargo build --release` is the
-only path today. A Homebrew tap is tracked in
-[#46](https://github.com/DrazThan/hermon/issues/46).
+```bash
+brew tap drazthan/hermon
+brew install hermon
+```
+
+The tap builds from source against Homebrew's `rust`, so the first install
+spends about half a minute compiling; there are no bottles or prebuilt
+binaries yet.
+
+From a checkout instead:
+
+```bash
+cargo install --path .
+```
+
+Either way `hermon --version` should print `hermon 0.1.0`.
 
 ## Quickstart
 

--- a/packaging/RELEASE_NOTES.md
+++ b/packaging/RELEASE_NOTES.md
@@ -1,0 +1,163 @@
+# hermon v0.1.0 — release and Homebrew tap
+
+Everything needed to cut the first release and publish the personal tap. The
+files in this repo (release profile, `.github/workflows/release.yml`,
+`packaging/homebrew/Formula/hermon.rb`) are ready; the steps below are the
+parts that need push/tag/repo-create rights and so have **not** been run.
+
+## 1. Release profile: measured before/after
+
+Added to `Cargo.toml`:
+
+```toml
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+```
+
+Measured on this machine — macOS 26.6.2, arm64 (Apple silicon),
+`rustc 1.98.0 (88d9e12ae 2026-08-18)` — with a clean `rm -rf target/release`
+before each build, `cargo build --release --locked`:
+
+| | Baseline (no `[profile.release]`) | Tuned | Change |
+|---|---|---|---|
+| Binary size | 5,834,592 B (5.56 MiB) | 4,270,480 B (4.07 MiB) | **−1,564,112 B, −26.8 %** |
+| Clean build time | 15.8 s | 28.8 s | +13.0 s (+82 %) |
+
+Startup, 150 interleaved runs per binary (alternating baseline/tuned each
+round so thermal drift hits both equally), timed from `subprocess.run` around
+the whole process:
+
+| Command | Baseline median | Tuned median | Baseline p90 | Tuned p90 |
+|---|---|---|---|---|
+| `hermon --version` | 2.68 ms | 2.64 ms | 3.03 ms | 2.83 ms |
+| `hermon ls` (empty fixture stores) | 2.78 ms | 2.73 ms | 3.04 ms | 2.97 ms |
+
+The `ls` figure points every source at paths with nothing behind them
+(`--claude-dir` at an empty dir, the two DBs and the log at nonexistent
+paths), so it measures process start + config + store-open + an empty scan
+without depending on whatever sessions happen to be live.
+
+Read that as: **size down ~27 %, startup unchanged.** The startup deltas
+(~0.04 ms, ~1.5 %) are inside run-to-run noise — a first, non-interleaved
+pass had the tuned binary looking *slower* by 0.5 ms, which is what motivated
+re-running interleaved. Nothing here is startup-bound; the win is the smaller
+download and a smaller resident binary. The cost is build time, which a
+source-building Homebrew formula pays once per install.
+
+Reproduce with:
+
+```bash
+rm -rf target/release && cargo build --release --locked && stat -f%z target/release/hermon
+```
+
+## 2. Tag and release (operator)
+
+From a clean checkout of `main` at the commit that carries these files:
+
+```bash
+git checkout main && git pull --ff-only
+git tag -a v0.1.0 -m "hermon v0.1.0"
+git push origin v0.1.0
+```
+
+Pushing the tag fires `.github/workflows/release.yml`, which runs the full
+suite (build, test, clippy, fmt, the legacy Python tests, plus a
+`cargo build --release` so the LTO profile is proven on Linux too), checks
+the tag matches `Cargo.toml`'s version, and then creates the GitHub release
+with generated notes. GitHub attaches the source tarball automatically — no
+binary artifacts are uploaded, since the tap builds from source.
+
+Watch it and confirm the release exists:
+
+```bash
+gh run watch --repo DrazThan/hermon "$(gh run list --repo DrazThan/hermon --workflow Release --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh release view v0.1.0 --repo DrazThan/hermon
+```
+
+If CI is red, delete the tag (`git push --delete origin v0.1.0 && git tag -d
+v0.1.0`), fix, and re-tag — the release job only runs after the test job
+passes, so a red run leaves no release behind.
+
+## 3. Fill in the formula's sha256
+
+`packaging/homebrew/Formula/hermon.rb` ships with an all-zeros placeholder:
+
+```ruby
+sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+```
+
+Once the tag exists, get the real digest of GitHub's source tarball:
+
+```bash
+curl -fsSL https://github.com/DrazThan/hermon/archive/refs/tags/v0.1.0.tar.gz | shasum -a 256
+```
+
+That prints `<digest>  -`; paste `<digest>` over the zeros. (Homebrew's
+`brew fetch --formula ./Formula/hermon.rb` won't help until the digest is
+right — it verifies against it.)
+
+## 4. Create the tap repo (operator)
+
+The tap is a plain GitHub repo named `homebrew-hermon`; Homebrew maps
+`drazthan/hermon` to `github.com/DrazThan/homebrew-hermon`.
+
+```bash
+cd "$(mktemp -d)"
+gh repo create DrazThan/homebrew-hermon --public --description "Homebrew tap for hermon" --clone
+cd homebrew-hermon
+mkdir -p Formula
+cp /path/to/hermon/packaging/homebrew/Formula/hermon.rb Formula/hermon.rb
+# make sure the sha256 from step 3 is in place before committing
+git add Formula/hermon.rb
+git commit -m "hermon 0.1.0"
+git push
+```
+
+`packaging/homebrew/Formula/hermon.rb` in this repo stays the source of
+truth; the tap repo gets a copy. On the next release, bump `url`, `sha256`
+and re-copy.
+
+## 5. Verify the tap on a clean machine
+
+```bash
+brew tap drazthan/hermon
+brew install hermon
+hermon --version    # expect: hermon 0.1.0
+hermon ls
+```
+
+Paste that transcript into issue #46. If a stale copy is already installed,
+`brew uninstall hermon && brew untap drazthan/hermon` first; add
+`--verbose --build-from-source` to `brew install` when a build fails and you
+need the cargo output.
+
+## 6. Audit status
+
+Run against the formula in a throwaway local tap, since `brew audit` refuses
+a bare file path (`Calling brew audit [path ...] is disabled`):
+
+```bash
+brew tap-new hermonaudit/scratch --no-git
+cp packaging/homebrew/Formula/hermon.rb "$(brew --repo hermonaudit/scratch)/Formula/hermon.rb"
+brew audit --strict hermonaudit/scratch/hermon
+brew style hermonaudit/scratch/hermon
+brew untap hermonaudit/scratch
+```
+
+Results here, Homebrew 6.0.20:
+
+- `brew audit --strict` — **passes**, no output, exit 0.
+- `brew style` — **passes**, "1 file inspected, no offenses detected".
+- `brew audit --strict --online` — **fails on one check only**, and expectedly:
+  `Stable: The source URL https://github.com/DrazThan/hermon/archive/refs/tags/v0.1.0.tar.gz is not reachable (HTTP status code 404)`,
+  because the tag doesn't exist yet. Re-run `--online` after step 2; it should
+  come back clean once the digest from step 3 is in place.
+
+## 7. What's deliberately not here
+
+No signed or notarized binaries, no bottles, no homebrew-core submission, no
+Linux packages. Every `brew install hermon` compiles from source against the
+`rust` build dependency. That's the right trade until there are enough users
+for a cold install's ~30 s of LTO to matter.

--- a/packaging/homebrew/Formula/hermon.rb
+++ b/packaging/homebrew/Formula/hermon.rb
@@ -1,0 +1,28 @@
+class Hermon < Formula
+  desc "Live monitor deck for Hermes, Claude Code, and OpenCode agent sessions"
+  homepage "https://github.com/DrazThan/hermon"
+  url "https://github.com/DrazThan/hermon/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+  license "MIT"
+  head "https://github.com/DrazThan/hermon.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "hermon #{version}", shell_output("#{bin}/hermon --version")
+
+    # Point every source at a path with nothing in it: the roster must come up
+    # empty rather than reading the test machine's real session stores.
+    (testpath/"claude").mkpath
+    output = shell_output("#{bin}/hermon ls " \
+                          "--claude-dir #{testpath}/claude " \
+                          "--hermes-db #{testpath}/absent-hermes.db " \
+                          "--opencode-db #{testpath}/absent-opencode.db " \
+                          "--hermes-log #{testpath}/absent-agent.log 2>&1")
+    assert_match "0 session(s)", output
+  end
+end


### PR DESCRIPTION
Implements #46. Measurements + runbook in packaging/RELEASE_NOTES.md.