### PR TITLE
gui: sortable roster table with selection and totals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_extras"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e651e08ddf6bb8bfd964ad70e33bc721c093f2b77ab59580e7140c008dab68c"
+dependencies = [
+ "ahash",
+ "egui",
+ "enum-map",
+ "itertools 0.15.0",
+ "log",
+ "mime_guess2",
+ "profiling",
+]
+
+[[package]]
 name = "egui_glow"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1442,26 @@ name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "enumflags2"
@@ -2254,6 +2289,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "eframe",
+ "egui_extras",
  "muda",
  "ratatui",
  "regex",
@@ -2846,6 +2882,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess2"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1706dc14a2e140dec0a7a07109d9a3d5890b81e85bd6c60b906b249a77adf0ca"
+dependencies = [
+ "mime",
+ "phf 0.11.3",
+ "phf_shared 0.11.3",
+ "unicase",
 ]
 
 [[package]]
@@ -3729,6 +3783,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+ "unicase",
 ]
 
 [[package]]
@@ -3751,6 +3806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
+ "unicase",
 ]
 
 [[package]]
@@ -5149,6 +5205,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-general-category"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4.6.6", features = ["derive"] }
 crossterm = "0.29.0"
 dirs = "6.0.0"
 eframe = "0.36.1"
+egui_extras = "0.36.1"
 ratatui = "0.30.2"
 regex = "1.13.1"
 rusqlite = { version = "0.40.2", features = ["bundled"] }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -15,6 +15,7 @@
 //! [`view::apply`] and never orders them itself.
 
 pub mod palette;
+pub mod roster;
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc::{self, Receiver};
@@ -25,10 +26,10 @@ use eframe::egui;
 
 use crate::config::EngineConfig;
 use crate::engine::{Engine, Event, Lifecycle, UiCmd};
-use crate::render::{Sem, StyledLine, fmt_elapsed};
+use crate::render::StyledLine;
 use crate::roster::RosterRow;
 use crate::source::Liveness;
-use crate::view::{self, ViewState};
+use crate::view::ViewState;
 
 /// Transcript lines kept per open pane, as in [`crate::ui`]: far more than
 /// any viewport shows, since the surplus is what #76's scrollback reads.
@@ -40,6 +41,13 @@ const MIN_WINDOW_SIZE: [f32; 2] = [480.0, 320.0];
 /// Opens the window and blocks until it closes, then shuts the engine down
 /// and joins it.
 pub fn run_gui(config: EngineConfig) -> anyhow::Result<()> {
+    // The store paths the engine is watching, for the empty state — taken
+    // before `config` moves into the engine below.
+    let paths = vec![
+        config.claude_dir.clone(),
+        config.hermes_db.clone(),
+        config.opencode_db.clone(),
+    ];
     let (event_tx, event_rx) = mpsc::channel();
     let (cmd_tx, cmd_rx) = mpsc::channel();
     let engine = Engine::spawn(config, event_tx, cmd_rx);
@@ -58,7 +66,7 @@ pub fn run_gui(config: EngineConfig) -> anyhow::Result<()> {
         Box::new(move |cc| {
             palette::install(&cc.egui_ctx);
             let events = event_rx.take().expect("app creator runs once");
-            Ok(Box::new(App::new(wake(events, cc.egui_ctx.clone()))))
+            Ok(Box::new(App::new(wake(events, cc.egui_ctx.clone()), paths)))
         }),
     );
 
@@ -107,8 +115,11 @@ pub struct App {
     /// panes; until then the engine tails nothing and this stays empty.
     pub panes: HashMap<String, VecDeque<StyledLine>>,
     /// The active sort, filter and attention-first flag (#40's pure core),
-    /// which #77's controls drive.
+    /// which #75's header clicks and #77's controls drive.
     pub view: ViewState,
+    /// The store paths the engine is watching, for the empty state —
+    /// [`crate::ui::App::paths`]'s desktop twin.
+    pub paths: Vec<String>,
     events: Receiver<Event>,
     /// The title last pushed to the window, so an unchanged one costs no
     /// viewport command.
@@ -116,13 +127,14 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(events: Receiver<Event>) -> Self {
+    pub fn new(events: Receiver<Event>, paths: Vec<String>) -> Self {
         App {
             roster: Vec::new(),
             ticker: Vec::new(),
             selected_id: None,
             panes: HashMap::new(),
             view: ViewState::default(),
+            paths,
             events,
             title: Self::default_title(),
         }
@@ -193,27 +205,11 @@ impl App {
         }
     }
 
-    /// The body: one label per session, proving the event loop lands on
-    /// screen. Real widgets are #75's.
-    fn draw(&self, ui: &mut egui::Ui) {
-        let rows = view::apply(&self.roster, &self.view).rows;
-        if rows.is_empty() {
-            ui.label(egui::RichText::new("no sessions").color(palette::DIM));
-            return;
-        }
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            for row in rows {
-                let (glyph, color) = palette::glyph_for_liveness(row.state);
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new(glyph).color(color).monospace());
-                    ui.label(
-                        egui::RichText::new(row_line(row))
-                            .color(palette::color(Sem::Plain))
-                            .monospace(),
-                    );
-                });
-            }
-        });
+    /// The body: the fleet table, real widgets and all — [`roster::render`]
+    /// owns the layout, this stays a thin call so the update path is still
+    /// one function ([`App::apply_event`]) tests can drive without a window.
+    fn draw(&mut self, ui: &mut egui::Ui) {
+        roster::render(ui, self);
     }
 }
 
@@ -238,17 +234,6 @@ fn title_for(live: usize) -> String {
     format!("hermon \u{2014} {live} live")
 }
 
-/// One session as plain text: `C:0f865f  sonnet-4.5  Bash  3m07s`.
-fn row_line(row: &RosterRow) -> String {
-    format!(
-        "{}  {}  {}  {}",
-        row.key,
-        row.model,
-        row.last_tool,
-        fmt_elapsed(row.elapsed)
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc::Sender;
@@ -257,6 +242,7 @@ mod tests {
     use super::*;
     use crate::engine::Cause;
     use crate::source::Attn;
+    use crate::view;
 
     fn row(key: &str, state: Liveness) -> RosterRow {
         RosterRow {
@@ -278,7 +264,7 @@ mod tests {
 
     fn app() -> (Sender<Event>, App) {
         let (tx, rx) = mpsc::channel();
-        (tx, App::new(rx))
+        (tx, App::new(rx, Vec::new()))
     }
 
     /// One egui pass with no window behind it. The output carries texture
@@ -361,7 +347,7 @@ mod tests {
     fn a_quiet_window_settles_and_an_engine_event_wakes_it() {
         let ctx = egui::Context::default();
         let (tx, engine_rx) = mpsc::channel();
-        let mut app = App::new(wake(engine_rx, ctx.clone()));
+        let mut app = App::new(wake(engine_rx, ctx.clone()), Vec::new());
         app.apply_event(Event::Roster(vec![row("C:aaa", Liveness::Live)]));
 
         // A fresh context takes a pass or two to settle (fonts, first
@@ -419,6 +405,32 @@ mod tests {
         app.view.set_filter("key=H:*").unwrap();
         let rows = view::apply(&app.roster, &app.view).rows;
         assert_eq!(rows.len(), 1);
-        assert_eq!(row_line(rows[0]), "H:bbb  sonnet-4.5  Bash  3m07s");
+        assert_eq!(rows[0].key, "H:bbb");
+    }
+
+    /// The table's selection is keyed by [`RosterRow::id`], the same
+    /// invariant [`ViewState::pinned`] relies on: a tick that reorders the
+    /// roster must not lose or shift the cursor.
+    #[test]
+    fn selection_survives_a_tick_reorder() {
+        let (_tx, mut app) = app();
+        app.apply_event(Event::Roster(vec![
+            row("C:aaa", Liveness::Live),
+            row("H:bbb", Liveness::Live),
+        ]));
+        app.selected_id = Some("H:bbb-id".to_string());
+
+        // Newest activity first next tick: the same two sessions, reversed.
+        app.apply_event(Event::Roster(vec![
+            row("H:bbb", Liveness::Live),
+            row("C:aaa", Liveness::Live),
+        ]));
+
+        let rows = view::apply(&app.roster, &app.view).rows;
+        assert_eq!(app.selected_id.as_deref(), Some("H:bbb-id"));
+        assert!(
+            rows.iter()
+                .any(|r| Some(r.id.as_str()) == app.selected_id.as_deref())
+        );
     }
 }

--- a/src/gui/roster.rs
+++ b/src/gui/roster.rs
@@ -1,0 +1,252 @@
+//! The fleet table: sortable columns, attention colors, selection and
+//! totals — the desktop twin of [`crate::ui::roster`]'s list mode.
+//!
+//! Every bit of row logic — attention grouping, sort order, the empty
+//! states — is read through [`crate::view`] and [`crate::ui::roster`]; this
+//! module only turns their output into egui widgets. Sort state and the
+//! selected session id live on [`super::App`], not here, so #76 and #77 can
+//! read and drive the same fields.
+
+use eframe::egui::{self, Color32, RichText, Ui};
+use egui_extras::{Column, TableBuilder, TableRow};
+
+use crate::render::{StyledLine, fmt_elapsed};
+use crate::roster::{RosterRow, commas, fmt_cost, tool_annotation, totals_line};
+use crate::ui::roster::{empty_state, no_matches_state, row_sems};
+use crate::view::{self, SortKey, ViewState};
+
+use super::App;
+use super::palette;
+
+const ROW_HEIGHT: f32 = 20.0;
+const HEADER_HEIGHT: f32 = 22.0;
+
+/// Draws the top bar, the fleet table (or the matching empty state), and
+/// the totals/ticker status strip into `ui`.
+pub fn render(ui: &mut Ui, app: &mut App) {
+    render_top_bar(ui, app);
+    ui.separator();
+
+    if app.roster.is_empty() {
+        render_lines(ui, &empty_state(&app.paths));
+        return;
+    }
+
+    let output = view::apply(&app.roster, &app.view);
+    if output.rows.is_empty() {
+        render_lines(ui, &no_matches_state());
+        ui.separator();
+        render_status_strip(ui, app);
+        return;
+    }
+    let rows = output.rows;
+
+    let selected_id = app.selected_id.clone();
+    let mut sort_click: Option<SortKey> = None;
+    let mut select_click: Option<String> = None;
+
+    egui::ScrollArea::vertical()
+        .id_salt("roster-table")
+        .show(ui, |ui| {
+            TableBuilder::new(ui)
+                .striped(true)
+                .sense(egui::Sense::click())
+                .column(Column::exact(24.0))
+                .column(Column::initial(90.0).at_least(70.0))
+                .column(Column::initial(130.0).at_least(90.0))
+                .column(Column::remainder().at_least(100.0))
+                .column(Column::initial(120.0).at_least(90.0))
+                .column(Column::initial(80.0).at_least(60.0))
+                .column(Column::initial(80.0).at_least(60.0))
+                .header(HEADER_HEIGHT, |mut header| {
+                    header.col(|_| {});
+                    header.col(|ui| {
+                        ui.label(RichText::new("key").color(palette::DIM));
+                    });
+                    sort_header(&mut header, &app.view, SortKey::Model, &mut sort_click);
+                    sort_header(&mut header, &app.view, SortKey::Tool, &mut sort_click);
+                    sort_header(&mut header, &app.view, SortKey::InOut, &mut sort_click);
+                    sort_header(&mut header, &app.view, SortKey::Cost, &mut sort_click);
+                    sort_header(&mut header, &app.view, SortKey::Elapsed, &mut sort_click);
+                })
+                .body(|body| {
+                    body.rows(ROW_HEIGHT, rows.len(), |mut row| {
+                        let r = rows[row.index()];
+                        row.set_selected(selected_id.as_deref() == Some(r.id.as_str()));
+                        row_cells(&mut row, r);
+                        if row.response().clicked() {
+                            select_click = Some(r.id.clone());
+                        }
+                    });
+                });
+        });
+
+    if let Some(key) = sort_click {
+        app.view.toggle_sort(key);
+    }
+    if let Some(id) = select_click {
+        app.selected_id = Some(id);
+    }
+
+    ui.separator();
+    render_status_strip(ui, app);
+}
+
+/// The attention-first toggle — the desktop-native stand-in for the TUI's
+/// `[a]` key. #77 adds the filter box and pin controls next to it.
+fn render_top_bar(ui: &mut Ui, app: &mut App) {
+    ui.horizontal(|ui| {
+        ui.toggle_value(&mut app.view.attention_first, "⚠ attention first");
+    });
+}
+
+/// One sortable header cell: the column label plus the active sort's arrow,
+/// clickable to activate the key or flip its direction via
+/// [`ViewState::toggle_sort`].
+fn sort_header(
+    header: &mut TableRow<'_, '_>,
+    view: &ViewState,
+    key: SortKey,
+    clicked: &mut Option<SortKey>,
+) {
+    header.col(|ui| {
+        let label = match view.sort_key {
+            Some(active) if active == key => format!("{} {}", key.label(), view.sort_dir.arrow()),
+            _ => key.label().to_string(),
+        };
+        if ui
+            .add(egui::Button::new(RichText::new(label).color(palette::DIM)).frame(false))
+            .clicked()
+        {
+            *clicked = Some(key);
+        }
+    });
+}
+
+/// One row's seven cells, colored by the row's attention state through the
+/// same [`row_sems`] mapping the TUI paints with.
+fn row_cells(row: &mut TableRow<'_, '_>, r: &RosterRow) {
+    let sems = row_sems(r.state);
+    let (glyph, glyph_color) = palette::glyph_for_liveness(r.state);
+    row.col(|ui| {
+        ui.label(mono(glyph, glyph_color));
+    });
+    row.col(|ui| {
+        ui.label(mono(&r.key, palette::color(sems.text)));
+    });
+    row.col(|ui| {
+        ui.label(mono(&r.model, palette::color(sems.text)));
+    });
+    row.col(|ui| {
+        ui.label(mono(&tool_annotation(r), palette::color(sems.text)));
+    });
+    row.col(|ui| {
+        ui.label(mono(&inout_text(r), palette::color(sems.meta)));
+    });
+    row.col(|ui| {
+        ui.label(mono(&fmt_cost(r.cost), palette::color(sems.cost)));
+    });
+    row.col(|ui| {
+        ui.label(mono(&fmt_elapsed(r.elapsed), palette::color(sems.meta)));
+    });
+}
+
+/// `12,345/6,789`, the IN/OUT column's text — [`SortKey::InOut`] orders by
+/// the same two fields summed.
+fn inout_text(r: &RosterRow) -> String {
+    format!("{}/{}", commas(r.in_tok), commas(r.out_tok))
+}
+
+fn mono(text: &str, color: Color32) -> RichText {
+    RichText::new(text.to_string()).color(color).monospace()
+}
+
+/// Fleet totals ([`totals_line`]) plus the Hermes API-call ticker
+/// [`App::apply_event`] already keeps current — the same content `hermon
+/// ls` prints under its table.
+fn render_status_strip(ui: &mut Ui, app: &App) {
+    render_lines(ui, std::slice::from_ref(&totals_line(&app.roster)));
+    if !app.ticker.is_empty() {
+        render_lines(ui, &app.ticker);
+    }
+}
+
+/// Renders [`StyledLine`]s with each [`Seg`](crate::render::Seg)'s semantic
+/// color, the same text both `hermon ls` and the TUI show.
+fn render_lines(ui: &mut Ui, lines: &[StyledLine]) {
+    for line in lines {
+        if line.0.is_empty() {
+            ui.label("");
+            continue;
+        }
+        ui.horizontal(|ui| {
+            ui.spacing_mut().item_spacing.x = 0.0;
+            for seg in &line.0 {
+                ui.label(mono(&seg.text, palette::color(seg.sem)));
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+
+    use super::*;
+    use crate::engine::Event;
+    use crate::source::{Attn, Liveness};
+
+    fn row(key: &str, state: Liveness) -> RosterRow {
+        RosterRow {
+            id: format!("{key}-id"),
+            key: key.to_string(),
+            state,
+            model: "sonnet-4.5".to_string(),
+            last_tool: "Bash".to_string(),
+            last_line: "running".to_string(),
+            in_tok: 1_234,
+            out_tok: 56,
+            cost: Some(1.5),
+            elapsed: Some(187.0),
+            last_ts: 0.0,
+            title: "t".to_string(),
+            attn_elapsed: None,
+        }
+    }
+
+    #[test]
+    fn inout_text_combines_commas_in_and_out() {
+        assert_eq!(inout_text(&row("C:aaa", Liveness::Live)), "1,234/56");
+    }
+
+    /// One egui pass with no window behind it, matching [`super::super`]'s
+    /// own headless test helper.
+    fn pass(ctx: &egui::Context, ui: impl FnMut(&mut Ui)) {
+        let mut out = ctx.run_ui(egui::RawInput::default(), ui);
+        out.textures_delta.clear();
+    }
+
+    /// Every branch [`render`] can take must lay out without panicking: a
+    /// bare deck, a populated fleet with the selection on and off a row and
+    /// the ticker showing, and a filter that hides every row.
+    #[test]
+    fn render_lays_out_every_branch() {
+        let ctx = egui::Context::default();
+        let (_tx, rx) = mpsc::channel();
+        let mut app = App::new(rx, vec!["/tmp/claude".to_string()]);
+        pass(&ctx, |ui| render(ui, &mut app));
+
+        app.apply_event(Event::Roster(vec![
+            row("C:aaa", Liveness::Live),
+            row("H:bbb", Liveness::Attention(Attn::Stuck)),
+        ]));
+        app.selected_id = Some("C:aaa-id".to_string());
+        app.apply_event(Event::Ticker(vec![StyledLine::default()]));
+        pass(&ctx, |ui| render(ui, &mut app));
+
+        app.view
+            .set_filter("model=nomatch*")
+            .expect("filter parses");
+        pass(&ctx, |ui| render(ui, &mut app));
+    }
+}

--- a/src/roster.rs
+++ b/src/roster.rs
@@ -369,7 +369,7 @@ pub(crate) fn totals_line(rows: &[RosterRow]) -> StyledLine {
 /// tool-pending ceiling has made it look stuck). Silent outside attention,
 /// and when `attn_elapsed` hasn't been populated (`hermon ls`'s one-shot
 /// roster has no tick history to compute it from).
-fn tool_annotation(r: &RosterRow) -> String {
+pub(crate) fn tool_annotation(r: &RosterRow) -> String {
     match r.state {
         Liveness::Attention(Attn::PermWait) => format!("{} · perm?", r.last_tool),
         Liveness::Attention(Attn::Stuck) => match r.attn_elapsed {

--- a/src/ui/roster.rs
+++ b/src/ui/roster.rs
@@ -144,7 +144,7 @@ pub fn row_sems(state: Liveness) -> RowSems {
 }
 
 /// What the roster says when a filter is active but matches nothing.
-fn no_matches_state() -> Vec<StyledLine> {
+pub(crate) fn no_matches_state() -> Vec<StyledLine> {
     vec![StyledLine(vec![Seg::new(
         Sem::Dim,
         "no sessions match the active filter",
@@ -152,7 +152,7 @@ fn no_matches_state() -> Vec<StyledLine> {
 }
 
 /// What a fresh, sessionless deck says: nothing found, and where it looked.
-fn empty_state(paths: &[String]) -> Vec<StyledLine> {
+pub(crate) fn empty_state(paths: &[String]) -> Vec<StyledLine> {
     let mut lines = vec![
         StyledLine(vec![Seg::new(Sem::Dim, "no agent sessions found")]),
         StyledLine::default(),


### PR DESCRIPTION
########## ISSUE #75 ##########
Desktop roster table: sortable columns, selection, totals
Blocked by #74.
MODEL: sonnet5 — mid-size widget work with the row logic already written; the spec pins every column and behavior.

**In plain terms:** The real fleet table in the desktop window: sortable columns, attention colors, selection, totals — the desktop twin of the TUI's list mode.

---

**Why**
Artboard 2b, third rendering of it (plain `ls`, TUI list, now desktop). All row logic exists (`RosterRow`, view.rs attention-sort); this is egui table work.

**What to build**
Repo specifics: new file `src/gui/roster.rs` in the module layout #74 established; app state lives in `src/gui/mod.rs`, colors via the `Sem -> egui::Color32` mapping in `src/gui/palette.rs`. Sorting uses view.rs's `SortKey { Model, Tool, InOut, Cost, Elapsed }` with its existing `toggle_sort`/arrow helpers — the gui stores a `ViewState` and calls view.rs; NEVER reimplement sort/attention logic. Cost/token formatting reuses the pure helpers from #69 (`—` for unknown cost, compacted counts). Selection keyed by `RosterRow::id` — the same invariant `ViewState.pinned` uses.
- Table via `egui_extras::TableBuilder` (VERIFY the current egui_extras version on crates.io matches the eframe/egui versions #74 pinned, and its API on docs.rs) in `src/gui/roster.rs`: columns glyph · KEY · MODEL · TOOL · IN/OUT · COST · ELAPSED, matching the `ls` column rules incl. the #69 fixes.
- Row coloring per state (attention amber/red, done dim) via the palette mapping; click selects (selection keyed by session id, surviving reorder — port the TUI invariant); selected row highlighted with the selection color.
- Clickable column headers sort via the existing view.rs `SortKey` (click again flips ↑↓, indicator arrow in the header) — desktop-native sorting instead of the TUI palette overlay; attention-sort as a toggle button in a top bar.
- Fleet totals + api ticker (`Event::Ticker` lines already drained by #74's plumbing) as a status strip under the table.
- Empty state matching the TUI's ("no agent sessions found" + watched paths).
Seam note: #76 renders the selected session's pane under this table and #77 adds filter/pin to the top bar — expose the selected session id and the top-bar area cleanly in app state; keep the sort-state in `ViewState`, not a gui-local copy.

**Out of scope**
Session panes (#76). Filter box and pinning (#77).

**Acceptance criteria**
- Screenshot in PR against the real fleet; counts/values match `hermon ls` output side-by-side.
- Sort clicks exercise every column both directions; selection survives a tick reorder (test the state logic; UI-level assertion best-effort).
- `cargo test` + CI green.