### PR TITLE
arbitration: single-notifier pidfile, mute toggle, attention icon

### DIFF
--- a/src/arbitration.rs
+++ b/src/arbitration.rs
@@ -1,0 +1,428 @@
+//! Which hermon process gets to deliver desktop banners.
+//!
+//! Every UI (`watch`, `gui`, `menubar`) runs its own [`crate::engine::Engine`],
+//! and the engine fires notifications — so two UIs open at once means every
+//! banner arrives twice. The fix is a claim, not a lock: whichever process is
+//! actually notifying writes a pidfile named after its [`UiKind`] into the
+//! user's runtime dir, and a starting process that finds a *higher-precedence*
+//! kind already holding one defaults its own notifications off.
+//!
+//! Precedence is [`UiKind::rank`]: `menubar` > `gui` > `watch`, the
+//! always-running process winning over the transient one. An explicit
+//! `--notify` / `--no-notify` always beats the default resolution, so the
+//! arbitration only ever decides what happens when the user said nothing.
+//!
+//! The pidfile is state about hermon itself, not about the agents, so this
+//! leaves the engine's read-only-stores principle alone. Nothing here mutates
+//! or reads a session store.
+//!
+//! Two caveats, both deliberate: a second instance of the *same* kind
+//! overwrites the first's pidfile rather than deferring to it (two menu-bar
+//! icons is already user error), and mute state is per-process — muting in the
+//! TUI does not mute the menu bar.
+
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// A hermon UI that can hold the notifier role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UiKind {
+    Watch,
+    Gui,
+    Menubar,
+}
+
+impl UiKind {
+    /// Highest precedence first, so [`decide`] can stop at the first holder
+    /// it finds.
+    const BY_RANK: [UiKind; 3] = [UiKind::Menubar, UiKind::Gui, UiKind::Watch];
+
+    /// Bigger wins. The menu bar is the process that is always up, so it is
+    /// the one banners should come from.
+    fn rank(self) -> u8 {
+        match self {
+            UiKind::Watch => 0,
+            UiKind::Gui => 1,
+            UiKind::Menubar => 2,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            UiKind::Watch => "watch",
+            UiKind::Gui => "gui",
+            UiKind::Menubar => "menubar",
+        }
+    }
+
+    fn pidfile(self) -> String {
+        format!("{}.pid", self.name())
+    }
+}
+
+impl fmt::Display for UiKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// What the user asked for on the command line. [`NotifyFlag::Default`] — no
+/// flag at all — is the only case arbitration gets a say in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotifyFlag {
+    Default,
+    /// `--notify`
+    ForceOn,
+    /// `--no-notify`
+    ForceOff,
+}
+
+/// The resolved answer for one process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Decision {
+    /// Whether this process should deliver banners at all.
+    pub notify: bool,
+    /// `Some(kind)` only when notifications defaulted off because that kind
+    /// is already notifying — the subject of `watch`'s one-line notice. Stays
+    /// `None` for an explicit `--no-notify`, which nobody needs telling about.
+    pub yielded_to: Option<UiKind>,
+}
+
+/// Where the pidfiles live: `$XDG_RUNTIME_DIR/hermon` where the platform has
+/// one, else the per-user cache dir (macOS has no runtime dir). `None` when
+/// neither exists, which simply disables arbitration — every process then
+/// notifies, the pre-#72 behaviour.
+pub fn runtime_dir() -> Option<PathBuf> {
+    dirs::runtime_dir()
+        .or_else(dirs::cache_dir)
+        .map(|d| d.join("hermon"))
+}
+
+/// Claims the notifier role for `kind` by writing this process's pid into
+/// `dir`. Only call this once the process has actually decided to notify —
+/// the pidfile means "this kind is delivering banners", not "this kind is
+/// running", so a `menubar --no-notify` must not claim it.
+pub fn claim(dir: &Path, kind: UiKind) -> io::Result<PidGuard> {
+    fs::create_dir_all(dir)?;
+    let path = dir.join(kind.pidfile());
+    fs::write(&path, format!("{}\n", std::process::id()))?;
+    Ok(PidGuard { path: Some(path) })
+}
+
+/// Removes the pidfile [`claim`] wrote, on drop or on an explicit
+/// [`PidGuard::release`]. The macOS event loop exits the process without
+/// unwinding, so the tray backend calls `release` itself rather than trusting
+/// the destructor to run.
+#[derive(Debug)]
+pub struct PidGuard {
+    path: Option<PathBuf>,
+}
+
+impl PidGuard {
+    pub fn release(&mut self) {
+        if let Some(path) = self.path.take() {
+            let _ = fs::remove_file(path);
+        }
+    }
+}
+
+impl Drop for PidGuard {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+/// `true` if `kind` has a pidfile in `dir` naming a process that still exists.
+/// A missing file, an unreadable or malformed one, and a stale pid all read
+/// the same way: nobody is holding that role.
+pub fn is_running(dir: &Path, kind: UiKind) -> bool {
+    is_running_with(dir, kind, pid_alive)
+}
+
+/// Resolves whether this process notifies. `dir` is `None` when the platform
+/// gave us nowhere to look, in which case no arbitration happens.
+pub fn decide(dir: Option<&Path>, kind: UiKind, flag: NotifyFlag) -> Decision {
+    decide_with(dir, kind, flag, pid_alive)
+}
+
+fn is_running_with(dir: &Path, kind: UiKind, alive: impl Fn(u32) -> bool) -> bool {
+    read_pid(&dir.join(kind.pidfile())).is_some_and(alive)
+}
+
+fn decide_with(
+    dir: Option<&Path>,
+    kind: UiKind,
+    flag: NotifyFlag,
+    alive: impl Fn(u32) -> bool + Copy,
+) -> Decision {
+    match flag {
+        NotifyFlag::ForceOn => {
+            return Decision {
+                notify: true,
+                yielded_to: None,
+            };
+        }
+        NotifyFlag::ForceOff => {
+            return Decision {
+                notify: false,
+                yielded_to: None,
+            };
+        }
+        NotifyFlag::Default => {}
+    }
+
+    let owner = dir.and_then(|dir| {
+        UiKind::BY_RANK
+            .into_iter()
+            .find(|other| other.rank() > kind.rank() && is_running_with(dir, *other, alive))
+    });
+    Decision {
+        notify: owner.is_none(),
+        yielded_to: owner,
+    }
+}
+
+fn read_pid(path: &Path) -> Option<u32> {
+    let pid: u32 = fs::read_to_string(path).ok()?.trim().parse().ok()?;
+    // `kill -0 0` addresses our own process group, which would always look
+    // alive; a pidfile claiming pid 0 is corrupt, not a live process.
+    (pid != 0).then_some(pid)
+}
+
+/// Does this pid exist? hermon has no `libc` dependency, so the POSIX
+/// `kill(pid, 0)` probe is spawned as `kill(1)` instead. That costs a process
+/// spawn, which is fine: this runs once at startup, never per tick. A `kill`
+/// we cannot run at all reads as "cannot prove it is alive" — the failure mode
+/// is a duplicate banner the user can silence with `--no-notify`, not a
+/// permanently muted hermon.
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(not(unix))]
+fn pid_alive(_pid: u32) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pid that is guaranteed not to be running: spawn a process, wait for
+    /// it, and use the id the kernel has now freed.
+    fn reaped_pid() -> u32 {
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "exit 0"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let pid = child.id();
+        child.wait().unwrap();
+        pid
+    }
+
+    fn write_pid(dir: &Path, kind: UiKind, pid: u32) {
+        fs::write(dir.join(kind.pidfile()), format!("{pid}\n")).unwrap();
+    }
+
+    // ------------------------------------------------ pidfile liveness check
+
+    #[test]
+    fn a_missing_pidfile_is_not_running() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_running(dir.path(), UiKind::Menubar));
+    }
+
+    #[test]
+    fn a_live_pid_is_running() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Menubar, std::process::id());
+        assert!(is_running(dir.path(), UiKind::Menubar));
+    }
+
+    #[test]
+    fn a_stale_pid_is_not_running() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Menubar, reaped_pid());
+        assert!(!is_running(dir.path(), UiKind::Menubar));
+    }
+
+    #[test]
+    fn a_malformed_pidfile_is_not_running() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(UiKind::Menubar.pidfile()), "not a pid").unwrap();
+        assert!(!is_running(dir.path(), UiKind::Menubar));
+        // Pid 0 would signal our own process group rather than a process.
+        fs::write(dir.path().join(UiKind::Menubar.pidfile()), "0").unwrap();
+        assert!(!is_running(dir.path(), UiKind::Menubar));
+    }
+
+    #[test]
+    fn each_kind_has_its_own_pidfile() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Menubar, std::process::id());
+        assert!(is_running(dir.path(), UiKind::Menubar));
+        assert!(!is_running(dir.path(), UiKind::Watch));
+    }
+
+    // ------------------------------------------------------------- the claim
+
+    #[test]
+    fn claim_writes_our_pid_and_the_guard_removes_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("hermon");
+        {
+            let _guard = claim(&nested, UiKind::Menubar).unwrap();
+            assert_eq!(
+                read_pid(&nested.join("menubar.pid")),
+                Some(std::process::id())
+            );
+            assert!(is_running(&nested, UiKind::Menubar));
+        }
+        assert!(!nested.join("menubar.pid").exists());
+    }
+
+    #[test]
+    fn release_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut guard = claim(dir.path(), UiKind::Menubar).unwrap();
+        guard.release();
+        guard.release();
+        assert!(!dir.path().join("menubar.pid").exists());
+    }
+
+    // -------------------------------------------------- defaults resolution
+
+    /// Precedence tests inject liveness so they neither spawn `kill` nor
+    /// depend on which pids the machine happens to have.
+    fn live(_pid: u32) -> bool {
+        true
+    }
+    fn dead(_pid: u32) -> bool {
+        false
+    }
+
+    fn decide_in(dir: &Path, kind: UiKind, alive: fn(u32) -> bool) -> Decision {
+        decide_with(Some(dir), kind, NotifyFlag::Default, alive)
+    }
+
+    #[test]
+    fn watch_notifies_when_nothing_else_does() {
+        let dir = tempfile::tempdir().unwrap();
+        let decision = decide_in(dir.path(), UiKind::Watch, live);
+        assert_eq!(
+            decision,
+            Decision {
+                notify: true,
+                yielded_to: None
+            }
+        );
+    }
+
+    #[test]
+    fn watch_yields_to_a_running_menubar() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Menubar, 4242);
+        let decision = decide_in(dir.path(), UiKind::Watch, live);
+        assert_eq!(
+            decision,
+            Decision {
+                notify: false,
+                yielded_to: Some(UiKind::Menubar)
+            }
+        );
+    }
+
+    #[test]
+    fn watch_ignores_a_stale_menubar_pidfile() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Menubar, 4242);
+        let decision = decide_in(dir.path(), UiKind::Watch, dead);
+        assert!(decision.notify);
+    }
+
+    #[test]
+    fn the_menubar_never_yields_to_a_lesser_ui() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Watch, 4242);
+        write_pid(dir.path(), UiKind::Gui, 4243);
+        let decision = decide_in(dir.path(), UiKind::Menubar, live);
+        assert!(decision.notify);
+    }
+
+    /// The seam #77 extends: `gui` sits between the two, so it yields upward
+    /// and holds against `watch` without any further change here.
+    #[test]
+    fn gui_yields_up_but_not_down() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Watch, 4242);
+        assert!(decide_in(dir.path(), UiKind::Gui, live).notify);
+
+        write_pid(dir.path(), UiKind::Menubar, 4243);
+        assert_eq!(
+            decide_in(dir.path(), UiKind::Gui, live).yielded_to,
+            Some(UiKind::Menubar)
+        );
+    }
+
+    #[test]
+    fn the_menubar_outranks_the_gui_as_the_reported_owner() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Gui, 4242);
+        write_pid(dir.path(), UiKind::Menubar, 4243);
+        assert_eq!(
+            decide_in(dir.path(), UiKind::Watch, live).yielded_to,
+            Some(UiKind::Menubar)
+        );
+    }
+
+    #[test]
+    fn explicit_notify_beats_a_running_menubar() {
+        let dir = tempfile::tempdir().unwrap();
+        write_pid(dir.path(), UiKind::Menubar, 4242);
+        let decision = decide_with(Some(dir.path()), UiKind::Watch, NotifyFlag::ForceOn, live);
+        assert_eq!(
+            decision,
+            Decision {
+                notify: true,
+                yielded_to: None
+            }
+        );
+    }
+
+    #[test]
+    fn explicit_no_notify_beats_an_empty_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let decision = decide_with(
+            Some(dir.path()),
+            UiKind::Menubar,
+            NotifyFlag::ForceOff,
+            live,
+        );
+        assert_eq!(
+            decision,
+            Decision {
+                notify: false,
+                yielded_to: None
+            }
+        );
+    }
+
+    #[test]
+    fn no_runtime_dir_means_no_arbitration() {
+        let decision = decide_with(None, UiKind::Watch, NotifyFlag::Default, live);
+        assert!(decision.notify);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@
 
 use clap::{Args, Parser, Subcommand};
 
+use crate::arbitration::NotifyFlag;
 use crate::notify::NotifyCfg;
 use crate::source::Replay;
 
@@ -99,6 +100,10 @@ pub struct SourceArgs {
     #[arg(long)]
     pub no_notify: bool,
 
+    /// Notify from this process even if a running menubar already is.
+    #[arg(long, conflicts_with = "no_notify")]
+    pub notify: bool,
+
     /// Per-(session, kind) cooldown before a turn-done/error alert can fire
     /// again for the same session.
     #[arg(long, default_value_t = NotifyCfg::default().cooldown_secs)]
@@ -145,6 +150,16 @@ impl SourceArgs {
             perm_wait: enabled && !self.no_notify_perm_wait,
             cooldown_secs: self.notify_cooldown,
             ..NotifyCfg::default()
+        }
+    }
+
+    /// Whether the user said anything about notifications at all —
+    /// [`crate::arbitration`] only decides the `Default` case.
+    pub fn notify_flag(&self) -> NotifyFlag {
+        match (self.notify, self.no_notify) {
+            (true, _) => NotifyFlag::ForceOn,
+            (_, true) => NotifyFlag::ForceOff,
+            _ => NotifyFlag::Default,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Greenfield rewrite of `hermon.py`, developed in the same repository so
 //! issues and PRs stay connected to the Python implementation it replaces.
 
+pub mod arbitration;
 pub mod cli;
 pub mod config;
 pub mod engine;
@@ -23,11 +24,30 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::anyhow;
 use clap::Parser;
 
+use arbitration::UiKind;
 use cli::{Cli, Command, LsArgs};
 use config::EngineConfig;
 use engine::PANE_TICK;
+use notify::NotifyCfg;
 use roster::{Sources, TICKER_LIMIT, api_call_ticker, build_roster, resolve_key, roster_lines};
 use source::Replay;
+
+/// The notify config this process actually runs with: what the flags asked
+/// for, minus the notifier role if a higher-precedence hermon UI already
+/// holds it (#72). Losing the role is worth a word on stderr — silence would
+/// just read as broken notifications.
+fn arbitrated_notify_cfg(args: &cli::SourceArgs, kind: UiKind) -> NotifyCfg {
+    let cfg = args.notify_cfg();
+    let dir = arbitration::runtime_dir();
+    let decision = arbitration::decide(dir.as_deref(), kind, args.notify_flag());
+    if decision.notify {
+        return cfg;
+    }
+    if let Some(owner) = decision.yielded_to {
+        eprintln!("hermon: {owner} instance is notifying; pass --notify to override");
+    }
+    cfg.silenced()
+}
 
 fn replay_from(src: &cli::SourceArgs) -> Replay {
     Replay {
@@ -43,7 +63,7 @@ pub fn run() -> anyhow::Result<()> {
         Command::Watch(args) => {
             // `watch` keeps the Python default 300s fresh window
             // (`hermon.py:1463`); only `ls` widens it to an hour.
-            let notify = args.notify_cfg();
+            let notify = arbitrated_notify_cfg(&args, UiKind::Watch);
             let replay = replay_from(&args);
             let config = EngineConfig {
                 claude_dir: args.claude_dir,
@@ -87,8 +107,11 @@ pub fn run() -> anyhow::Result<()> {
         Command::Render(args) => render(&args),
         Command::Menubar(args) => {
             // Same fresh window as `watch` (`hermon.py:1463`); menubar is
-            // the same live-fleet view, just in the status bar.
-            let notify = args.notify_cfg();
+            // the same live-fleet view, just in the status bar. Nothing
+            // outranks it, so this only ever honours an explicit flag — but
+            // it goes through the same seam so #77's `gui` slots in as one
+            // more arm.
+            let notify = arbitrated_notify_cfg(&args, UiKind::Menubar);
             let replay = replay_from(&args);
             let config = EngineConfig {
                 claude_dir: args.claude_dir,

--- a/src/menubar.rs
+++ b/src/menubar.rs
@@ -9,6 +9,7 @@
 //! logic; the event-loop wiring that drives it lives in [`mac`] so #71's
 //! dropdown menu and #72's arbitration have a narrow seam to extend.
 
+use crate::render::{Rgb, Sem};
 use crate::roster::{RosterRow, fmt_cost};
 use crate::source::{Attn, Liveness};
 use crate::ui::palette;
@@ -38,6 +39,10 @@ pub enum MenuRow {
     More { count: usize },
     /// Separator before actions
     Separator,
+    /// "Mute notifications", a checkmark item bound to the same mute the
+    /// TUI's `[m]` flips ([`crate::notify::AlertHistory::set_muted`]). The
+    /// mute is per-process: muting here does not mute a running `watch`.
+    MuteToggle { muted: bool },
     /// "Open hermon watch"
     OpenWatch,
     /// "Quit"
@@ -79,6 +84,17 @@ pub fn format_title(rows: &[RosterRow]) -> String {
     title
 }
 
+/// The status item's full title: [`format_title`] plus the mute glyph
+/// (`🔕`, or `[muted]` under `HERMON_ASCII`) while banners are silenced, so
+/// the menu bar says so without the dropdown having to be opened.
+pub fn status_title(rows: &[RosterRow], muted: bool) -> String {
+    let title = format_title(rows);
+    match palette::mute_indicator(muted) {
+        "" => title,
+        glyph => format!("{title} {glyph}"),
+    }
+}
+
 fn attention_count(rows: &[RosterRow], attn: Attn) -> usize {
     rows.iter()
         .filter(|r| r.state == Liveness::Attention(attn))
@@ -115,7 +131,7 @@ fn fmt_elapsed(seconds: Option<f64>) -> String {
 /// Build menu rows from the roster: attention-first sorted, capped at ~20,
 /// with fleet summary at top and Open/Quit actions at bottom. This is a pure
 /// function for testability — the caller wires it into the menu API.
-pub fn build_menu(rows: &[RosterRow]) -> Vec<MenuRow> {
+pub fn build_menu(rows: &[RosterRow], muted: bool) -> Vec<MenuRow> {
     let mut result = Vec::new();
 
     // Count states for the summary.
@@ -147,10 +163,109 @@ pub fn build_menu(rows: &[RosterRow]) -> Vec<MenuRow> {
 
     // Action items.
     result.push(MenuRow::Separator);
+    result.push(MenuRow::MuteToggle { muted });
     result.push(MenuRow::OpenWatch);
     result.push(MenuRow::Quit);
 
     result
+}
+
+/// The text one [`MenuRow`] shows in the dropdown. Pure and portable, so the
+/// macOS wiring only ever maps strings onto menu items — and so the labels
+/// are testable on any platform.
+pub fn menu_label(row: &MenuRow) -> String {
+    match row {
+        MenuRow::Summary { live, done, cost } => {
+            format!("{live} live · {done} done · Σ {cost}")
+        }
+        MenuRow::Session {
+            key,
+            model,
+            tool,
+            elapsed,
+            cost,
+            glyph,
+        } => {
+            let mut parts = vec![format!("{glyph} {key}")];
+            parts.extend(
+                [model, tool, elapsed, cost]
+                    .into_iter()
+                    .filter(|f| !f.is_empty())
+                    .cloned(),
+            );
+            parts.join(" · ")
+        }
+        MenuRow::More { count } => format!("… {count} more sessions"),
+        MenuRow::Separator => String::new(),
+        MenuRow::MuteToggle { .. } => "Mute notifications".to_string(),
+        MenuRow::OpenWatch => "Open hermon watch".to_string(),
+        MenuRow::Quit => "Quit".to_string(),
+    }
+}
+
+// ------------------------------------------------------------- status icon
+
+/// Pixel size of the status-bar dot. The tray backend scales whatever it is
+/// given down to 18pt, so this is drawn at 2× for retina.
+pub const ICON_PX: u32 = 36;
+
+/// Alpha the dot is drawn at while muted — still legible, visibly dimmed.
+const MUTED_ALPHA: u8 = 90;
+
+/// What the dot is currently saying. Tracked by the tray loop so the icon is
+/// only re-encoded when it would actually change, not on every roster tick.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IconState {
+    /// The most actionable attention state on the deck, if any.
+    pub attn: Option<Attn>,
+    pub muted: bool,
+}
+
+/// The icon's state from the same [`Liveness`] counts [`format_title`]
+/// reads. [`Attn::PermWait`] outranks [`Attn::Stuck`]: a session waiting on a
+/// permission prompt is blocked on the user specifically, where a wedged tool
+/// may still come back on its own.
+pub fn icon_state(rows: &[RosterRow], muted: bool) -> IconState {
+    let attn = if attention_count(rows, Attn::PermWait) > 0 {
+        Some(Attn::PermWait)
+    } else if attention_count(rows, Attn::Stuck) > 0 {
+        Some(Attn::Stuck)
+    } else {
+        None
+    };
+    IconState { attn, muted }
+}
+
+/// The dot as raw RGBA, so the menu bar needs no icon asset on disk: green
+/// while the fleet is fine, amber/red the moment something wants a human,
+/// dimmed while muted. Redundant with the counts in the title, which is the
+/// point — color is what peripheral vision catches.
+pub fn icon_rgba(state: IconState) -> Vec<u8> {
+    let color = match state.attn {
+        Some(Attn::PermWait) => Sem::User.color(),
+        Some(Attn::Stuck) => Sem::Error.color(),
+        None => Sem::Ok.color(),
+    };
+    let alpha = if state.muted { MUTED_ALPHA } else { 255 };
+    dot(color, alpha)
+}
+
+/// A filled circle with a one-pixel feathered edge — without the feather it
+/// reads as a square once the menu bar scales it down.
+fn dot(color: Rgb, alpha: u8) -> Vec<u8> {
+    let center = f64::from(ICON_PX - 1) / 2.0;
+    let radius = f64::from(ICON_PX) / 2.0 - 1.0;
+    let mut px = Vec::with_capacity((ICON_PX * ICON_PX * 4) as usize);
+    for y in 0..ICON_PX {
+        for x in 0..ICON_PX {
+            let dx = f64::from(x) - center;
+            let dy = f64::from(y) - center;
+            let coverage = (radius - dx.hypot(dy)).clamp(0.0, 1.0);
+            let a = (f64::from(alpha) * coverage).round() as u8;
+            px.extend_from_slice(&[color.r, color.g, color.b, a]);
+        }
+    }
+    px
 }
 
 /// Convert a RosterRow to a MenuRow session item.
@@ -279,8 +394,8 @@ mod tests {
 
     #[test]
     fn build_menu_empty_roster() {
-        let menu = build_menu(&[]);
-        assert_eq!(menu.len(), 4); // summary, separator, open watch, quit
+        let menu = build_menu(&[], false);
+        assert_eq!(menu.len(), 5); // summary, separator, mute, open watch, quit
         assert!(matches!(
             menu[0],
             MenuRow::Summary {
@@ -290,15 +405,16 @@ mod tests {
             }
         ));
         assert!(matches!(menu[1], MenuRow::Separator));
-        assert!(matches!(menu[2], MenuRow::OpenWatch));
-        assert!(matches!(menu[3], MenuRow::Quit));
+        assert!(matches!(menu[2], MenuRow::MuteToggle { muted: false }));
+        assert!(matches!(menu[3], MenuRow::OpenWatch));
+        assert!(matches!(menu[4], MenuRow::Quit));
     }
 
     #[test]
     fn build_menu_single_row() {
         let rows = vec![row("C:abc", Liveness::Live, Some(1.5), Some(120.0))];
-        let menu = build_menu(&rows);
-        assert_eq!(menu.len(), 5); // summary, session, separator, open watch, quit
+        let menu = build_menu(&rows, false);
+        assert_eq!(menu.len(), 6); // summary, session, separator, mute, open watch, quit
         assert!(matches!(
             menu[0],
             MenuRow::Summary {
@@ -328,7 +444,7 @@ mod tests {
                 Some(300.0),
             ),
         ];
-        let menu = build_menu(&rows);
+        let menu = build_menu(&rows, false);
         // Summary + stuck + perm + live + done + separator + open + quit
         let session_rows: Vec<_> = menu
             .iter()
@@ -348,7 +464,7 @@ mod tests {
             row("b", Liveness::Live, Some(2.5), None),
             row("c", Liveness::Done, Some(0.1), None),
         ];
-        let menu = build_menu(&rows);
+        let menu = build_menu(&rows, false);
         if let MenuRow::Summary { cost, .. } = &menu[0] {
             // Total is 4.1, formatted as $4.10
             assert_eq!(cost, "$4.10");
@@ -363,7 +479,7 @@ mod tests {
             row("a", Liveness::Live, None, None),
             row("b", Liveness::Live, Some(1.0), None),
         ];
-        let menu = build_menu(&rows);
+        let menu = build_menu(&rows, false);
         if let MenuRow::Summary { cost, .. } = &menu[0] {
             // Only known costs count: 1.0
             assert_eq!(cost, "$1.00");
@@ -377,7 +493,7 @@ mod tests {
         let rows: Vec<_> = (0..30)
             .map(|i| row(&format!("r{i}"), Liveness::Live, Some(0.1), Some(60.0)))
             .collect();
-        let menu = build_menu(&rows);
+        let menu = build_menu(&rows, false);
         let session_count = menu
             .iter()
             .filter(|m| matches!(m, MenuRow::Session { .. }))
@@ -394,18 +510,160 @@ mod tests {
         let rows: Vec<_> = (0..15)
             .map(|i| row(&format!("r{i}"), Liveness::Live, Some(0.1), Some(60.0)))
             .collect();
-        let menu = build_menu(&rows);
+        let menu = build_menu(&rows, false);
         assert!(!menu.iter().any(|m| matches!(m, MenuRow::More { .. })));
     }
 
     #[test]
     fn build_menu_actions_at_end() {
         let rows = vec![row("a", Liveness::Live, None, None)];
-        let menu = build_menu(&rows);
-        let last_three = &menu[menu.len() - 3..];
-        assert!(matches!(last_three[0], MenuRow::Separator));
-        assert!(matches!(last_three[1], MenuRow::OpenWatch));
-        assert!(matches!(last_three[2], MenuRow::Quit));
+        let menu = build_menu(&rows, false);
+        let tail = &menu[menu.len() - 4..];
+        assert!(matches!(tail[0], MenuRow::Separator));
+        assert!(matches!(tail[1], MenuRow::MuteToggle { .. }));
+        assert!(matches!(tail[2], MenuRow::OpenWatch));
+        assert!(matches!(tail[3], MenuRow::Quit));
+    }
+
+    #[test]
+    fn build_menu_mute_toggle_carries_the_current_state() {
+        let menu = build_menu(&[], true);
+        assert!(
+            menu.iter()
+                .any(|m| matches!(m, MenuRow::MuteToggle { muted: true }))
+        );
+    }
+
+    // ------------------------------------------------------------ mute + icon
+
+    #[test]
+    fn status_title_appends_the_mute_glyph_only_when_muted() {
+        let rows = vec![row("a", Liveness::Live, None, None)];
+        assert_eq!(status_title(&rows, false), format_title(&rows));
+        let muted = status_title(&rows, true);
+        assert!(muted.starts_with(&format_title(&rows)));
+        assert!(muted.ends_with(palette::mute_indicator(true)));
+    }
+
+    #[test]
+    fn icon_state_is_calm_without_attention() {
+        let rows = vec![
+            row("a", Liveness::Live, None, None),
+            row("b", Liveness::Done, None, None),
+        ];
+        assert_eq!(
+            icon_state(&rows, false),
+            IconState {
+                attn: None,
+                muted: false
+            }
+        );
+    }
+
+    #[test]
+    fn icon_state_flips_on_any_attention_row() {
+        let stuck = vec![row("a", Liveness::Attention(Attn::Stuck), None, None)];
+        assert_eq!(icon_state(&stuck, false).attn, Some(Attn::Stuck));
+
+        // A permission prompt blocks on the user specifically, so it wins
+        // over a merely wedged tool.
+        let both = vec![
+            row("a", Liveness::Attention(Attn::Stuck), None, None),
+            row("b", Liveness::Attention(Attn::PermWait), None, None),
+        ];
+        assert_eq!(icon_state(&both, false).attn, Some(Attn::PermWait));
+    }
+
+    #[test]
+    fn icon_state_carries_mute() {
+        assert!(icon_state(&[], true).muted);
+        assert!(!icon_state(&[], false).muted);
+    }
+
+    /// The center pixel is the dot's fill; the corner is outside the circle.
+    fn pixel(px: &[u8], x: u32, y: u32) -> [u8; 4] {
+        let i = ((y * ICON_PX + x) * 4) as usize;
+        [px[i], px[i + 1], px[i + 2], px[i + 3]]
+    }
+
+    #[test]
+    fn icon_is_a_full_rgba_buffer_with_a_transparent_corner() {
+        let px = icon_rgba(icon_state(&[], false));
+        assert_eq!(px.len(), (ICON_PX * ICON_PX * 4) as usize);
+        assert_eq!(pixel(&px, 0, 0)[3], 0, "corner is outside the dot");
+        assert_eq!(pixel(&px, ICON_PX / 2, ICON_PX / 2)[3], 255);
+    }
+
+    #[test]
+    fn icon_color_tracks_the_attention_state() {
+        let calm = icon_rgba(IconState {
+            attn: None,
+            muted: false,
+        });
+        let stuck = icon_rgba(IconState {
+            attn: Some(Attn::Stuck),
+            muted: false,
+        });
+        let perm = icon_rgba(IconState {
+            attn: Some(Attn::PermWait),
+            muted: false,
+        });
+        let mid = ICON_PX / 2;
+        assert_ne!(pixel(&calm, mid, mid), pixel(&stuck, mid, mid));
+        assert_ne!(pixel(&stuck, mid, mid), pixel(&perm, mid, mid));
+    }
+
+    #[test]
+    fn muting_dims_the_icon_without_changing_its_color() {
+        let state = IconState {
+            attn: Some(Attn::Stuck),
+            muted: false,
+        };
+        let lit = icon_rgba(state);
+        let dim = icon_rgba(IconState {
+            muted: true,
+            ..state
+        });
+        let mid = ICON_PX / 2;
+        assert_eq!(pixel(&lit, mid, mid)[..3], pixel(&dim, mid, mid)[..3]);
+        assert!(pixel(&dim, mid, mid)[3] < pixel(&lit, mid, mid)[3]);
+    }
+
+    // --------------------------------------------------------- menu labels
+
+    #[test]
+    fn menu_labels_read_as_one_line_each() {
+        let rows = vec![row("C:abc", Liveness::Live, Some(1.5), Some(120.0))];
+        let menu = build_menu(&rows, true);
+        let labels: Vec<String> = menu.iter().map(menu_label).collect();
+        assert_eq!(labels[0], "1 live · 0 done · Σ $1.50");
+        assert_eq!(
+            labels[1],
+            format!(
+                "{} C:abc · sonnet · Bash · 2m · $1.5000",
+                glyph(Liveness::Live)
+            )
+        );
+        assert_eq!(labels[labels.len() - 3], "Mute notifications");
+        assert_eq!(labels[labels.len() - 2], "Open hermon watch");
+        assert_eq!(labels[labels.len() - 1], "Quit");
+    }
+
+    #[test]
+    fn a_session_label_skips_fields_it_has_no_data_for() {
+        let mut r = row("H:zz", Liveness::Done, None, None);
+        r.model = String::new();
+        r.last_tool = String::new();
+        let label = menu_label(&build_menu(std::slice::from_ref(&r), false)[1]);
+        assert_eq!(label, format!("{} H:zz · —", glyph(Liveness::Done)));
+    }
+
+    #[test]
+    fn overflow_label_counts_the_hidden_sessions() {
+        assert_eq!(
+            menu_label(&MenuRow::More { count: 10 }),
+            "… 10 more sessions"
+        );
     }
 
     #[test]

--- a/src/menubar/mac.rs
+++ b/src/menubar/mac.rs
@@ -1,40 +1,66 @@
 //! The macOS tray backend: an NSStatusItem via `tray-icon`, driven by
 //! `tao`'s event loop (its required host — see the crate's platform notes).
 //! The engine runs on its own thread exactly as `watch` does
-//! ([`crate::ui::run_tui`]); this loop drains [`Event::Roster`] and keeps
-//! the status item's title in sync. #71's dropdown menu is built via the pure
-//! `build_menu` function; wiring it to the tray API is follow-up work with
-//! version-specific muda integration.
+//! ([`crate::ui::run_tui`]); this loop drains [`Event::Roster`] and keeps the
+//! status item's title, icon, and dropdown in sync.
+//!
+//! The dropdown is `muda`'s, built by mapping #71's pure [`build_menu`] rows
+//! onto menu items. It is rebuilt only when those rows actually change, both
+//! to avoid rebuilding an NSMenu every tick and because replacing the menu
+//! while the user has it open would dismiss it — session labels are minute-
+//! granular, so a quiet fleet leaves the menu alone entirely.
 
+use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+use muda::{CheckMenuItem, Menu, MenuEvent, MenuItem, PredefinedMenuItem};
 use tao::event::{Event as TaoEvent, StartCause};
 use tao::event_loop::{ControlFlow, EventLoop};
 use tao::platform::macos::{ActivationPolicy, EventLoopExtMacOS};
-use tray_icon::TrayIcon;
-use tray_icon::TrayIconBuilder;
+use tray_icon::{Icon, TrayIcon, TrayIconBuilder};
 
+use crate::arbitration::{self, PidGuard, UiKind};
 use crate::config::EngineConfig;
 use crate::engine::{Engine, Event, UiCmd};
+use crate::roster::RosterRow;
 
-use super::format_title;
+use super::{
+    ICON_PX, IconState, MenuRow, build_menu, icon_rgba, icon_state, menu_label, status_title,
+};
 
 /// How often the callback checks for a fresh roster — well under the ~2s
 /// the acceptance criteria asks the status item to react within.
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Ids for the three actionable rows. Menus are rebuilt wholesale, so the
+/// handler matches on these rather than on retained item handles.
+const ID_MUTE: &str = "hermon:mute";
+const ID_OPEN: &str = "hermon:open";
+const ID_QUIT: &str = "hermon:quit";
+
 pub fn run(config: EngineConfig) -> anyhow::Result<()> {
+    // The pidfile claims the notifier role, not merely "menubar is running":
+    // a `menubar --no-notify` must leave `watch` notifying (#72).
+    let pidfile = config.notify.any_enabled().then(claim_notifier).flatten();
+
     let (event_tx, event_rx) = mpsc::channel();
     let (cmd_tx, cmd_rx) = mpsc::channel();
     let engine = Engine::spawn(config, event_tx, cmd_rx);
     let mut engine = Some(engine);
+    let mut pidfile = pidfile;
 
     // Accessory: no Dock icon, no Cmd-Tab entry — a menu-bar-only app.
     let mut event_loop = EventLoop::new();
     event_loop.set_activation_policy(ActivationPolicy::Accessory);
 
     let mut tray: Option<TrayIcon> = None;
+    let mut rows: Vec<RosterRow> = Vec::new();
+    // The menubar's own mute, mirroring what the engine's `AlertHistory`
+    // holds. Per-process by design: the TUI's `[m]` does not reach here.
+    let mut muted = false;
+    let mut shown: Vec<MenuRow> = Vec::new();
+    let mut icon: Option<IconState> = None;
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::WaitUntil(Instant::now() + POLL_INTERVAL);
@@ -43,8 +69,17 @@ pub fn run(config: EngineConfig) -> anyhow::Result<()> {
             // tray-icon's own guidance (creating it any earlier has shown up
             // as a blank item on macOS).
             TaoEvent::NewEvents(StartCause::Init) => {
-                tray = match TrayIconBuilder::new().with_title(format_title(&[])).build() {
-                    Ok(icon) => Some(icon),
+                shown = build_menu(&rows, muted);
+                icon = Some(icon_state(&rows, muted));
+                let mut builder = TrayIconBuilder::new().with_title(status_title(&rows, muted));
+                if let Some(menu) = menu_from(&shown) {
+                    builder = builder.with_menu(Box::new(menu));
+                }
+                if let Some(icon) = icon.and_then(build_icon) {
+                    builder = builder.with_icon(icon);
+                }
+                tray = match builder.build() {
+                    Ok(item) => Some(item),
                     Err(err) => {
                         eprintln!("hermon menubar: failed to create tray icon: {err}");
                         None
@@ -52,25 +87,126 @@ pub fn run(config: EngineConfig) -> anyhow::Result<()> {
                 };
             }
             TaoEvent::MainEventsCleared => {
+                let mut fresh = false;
                 for engine_event in event_rx.try_iter() {
-                    if let Event::Roster(rows) = engine_event
-                        && let Some(tray) = &tray
-                    {
-                        tray.set_title(Some(format_title(&rows)));
+                    if let Event::Roster(new_rows) = engine_event {
+                        rows = new_rows;
+                        fresh = true;
+                    }
+                }
+
+                for menu_event in MenuEvent::receiver().try_iter() {
+                    match menu_event.id.as_ref() {
+                        ID_MUTE => {
+                            muted = !muted;
+                            if cmd_tx.send(UiCmd::SetMuted(muted)).is_err() {
+                                *control_flow = ControlFlow::Exit;
+                            }
+                            fresh = true;
+                        }
+                        ID_OPEN => open_watch(),
+                        ID_QUIT => *control_flow = ControlFlow::Exit,
+                        // Session and summary rows are readouts, not actions.
+                        _ => {}
+                    }
+                }
+
+                if fresh && let Some(tray) = &tray {
+                    tray.set_title(Some(status_title(&rows, muted)));
+
+                    let wanted = build_menu(&rows, muted);
+                    if wanted != shown {
+                        tray.set_menu(menu_from(&wanted).map(|m| Box::new(m) as _));
+                        shown = wanted;
+                    }
+
+                    let wanted = icon_state(&rows, muted);
+                    if icon != Some(wanted) {
+                        if let Some(built) = build_icon(wanted) {
+                            let _ = tray.set_icon(Some(built));
+                        }
+                        icon = Some(wanted);
                     }
                 }
             }
-            // Fires once, right before the process exits, once something
-            // sets `control_flow` to `Exit` — nothing does yet (#71's Quit
-            // menu item is the trigger), but the shutdown path is wired for
-            // it: tell the engine to stop and wait for its thread.
+            // Fires once, right before the process exits, once the Quit item
+            // sets `control_flow` to `Exit`: tell the engine to stop, wait for
+            // its thread, and drop the notifier claim. The claim is released
+            // by hand because the event loop exits the process outright —
+            // nothing here unwinds, so `PidGuard`'s destructor never runs.
             TaoEvent::LoopDestroyed => {
                 let _ = cmd_tx.send(UiCmd::Shutdown);
                 if let Some(handle) = engine.take() {
                     let _ = handle.join();
                 }
+                if let Some(guard) = &mut pidfile {
+                    guard.release();
+                }
             }
             _ => {}
         }
     })
+}
+
+fn claim_notifier() -> Option<PidGuard> {
+    let dir = arbitration::runtime_dir()?;
+    match arbitration::claim(&dir, UiKind::Menubar) {
+        Ok(guard) => Some(guard),
+        Err(err) => {
+            // Not fatal: the menubar still notifies, a concurrent `watch`
+            // just won't know to stand down.
+            eprintln!("hermon menubar: could not claim the notifier pidfile: {err}");
+            None
+        }
+    }
+}
+
+/// Maps the pure [`MenuRow`] list onto a `muda` menu. `None` if the menu API
+/// rejects an item, which leaves the status item menu-less rather than
+/// half-built.
+fn menu_from(items: &[MenuRow]) -> Option<Menu> {
+    let menu = Menu::new();
+    for item in items {
+        let label = menu_label(item);
+        let appended = match item {
+            MenuRow::Separator => menu.append(&PredefinedMenuItem::separator()),
+            MenuRow::MuteToggle { muted } => {
+                menu.append(&CheckMenuItem::with_id(ID_MUTE, label, true, *muted, None))
+            }
+            MenuRow::OpenWatch => menu.append(&MenuItem::with_id(ID_OPEN, label, true, None)),
+            MenuRow::Quit => menu.append(&MenuItem::with_id(ID_QUIT, label, true, None)),
+            // Readouts: shown, never clickable.
+            _ => menu.append(&MenuItem::new(label, false, None)),
+        };
+        if let Err(err) = appended {
+            eprintln!("hermon menubar: failed to build the dropdown: {err}");
+            return None;
+        }
+    }
+    Some(menu)
+}
+
+fn build_icon(state: IconState) -> Option<Icon> {
+    Icon::from_rgba(icon_rgba(state), ICON_PX, ICON_PX).ok()
+}
+
+/// Opens this same binary's TUI in Terminal.app — `open -a` cannot pass a
+/// subcommand, so it goes through AppleScript. Fire-and-forget, like
+/// [`crate::notify::deliver`]: a failure costs the user a menu click, not the
+/// menubar process.
+fn open_watch() {
+    let Ok(exe) = std::env::current_exe() else {
+        return;
+    };
+    let script = format!(
+        "tell application \"Terminal\" to do script \"{} watch\"\n\
+         tell application \"Terminal\" to activate",
+        crate::notify::applescript_escape(&exe.display().to_string())
+    );
+    let _ = Command::new("osascript")
+        .args(["-e", &script])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn();
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -94,6 +94,28 @@ pub struct NotifyCfg {
     pub min_session_secs: f64,
 }
 
+impl NotifyCfg {
+    /// Every alert kind off, tuning untouched — what a process that lost
+    /// [`crate::arbitration`] runs with. Distinct from `--no-notify` only in
+    /// where it comes from; the engine cannot tell the two apart, and
+    /// shouldn't.
+    pub fn silenced(self) -> Self {
+        NotifyCfg {
+            turn_done: false,
+            error: false,
+            stuck: false,
+            perm_wait: false,
+            ..self
+        }
+    }
+
+    /// Whether any kind can still fire — the test for "this process is a
+    /// notifier", which is what claiming an arbitration pidfile asserts.
+    pub fn any_enabled(&self) -> bool {
+        self.turn_done || self.error || self.stuck || self.perm_wait
+    }
+}
+
 impl Default for NotifyCfg {
     fn default() -> Self {
         NotifyCfg {
@@ -345,7 +367,7 @@ pub fn probe() -> Notifier {
 /// Escapes `"` and `\` for embedding in a double-quoted AppleScript string
 /// literal. Order matters: backslashes first, so escaping a quote doesn't
 /// double-escape the backslash that `"` → `\"` just introduced.
-fn applescript_escape(s: &str) -> String {
+pub(crate) fn applescript_escape(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 


### PR DESCRIPTION
########## ISSUE #72 ##########
Single-notifier arbitration, mute toggle, attention icon
Blocked by #71.
MODEL: opus5 — cross-process arbitration with precedence and override semantics, subtle cross-module invariants (NotifyCfg defaults, pidfile liveness, mute state, icon state); #77 builds directly on this seam, so it must be right.

**In plain terms:** Make the menu-bar app the one voice that sends notification banners, so running it alongside the TUI never double-notifies — and give it a mute toggle.

---

**Why**
Both `watch` and `menubar` run the engine, and the engine fires notifications — two processes means every banner arrives twice. The menu-bar app is the always-running process, so it becomes the default notifier.

**What to build**
Repo specifics: notification machinery is notify.rs — `NotifyCfg` flags (already shared by watch), `decide_alerts()`, `Notifier::probe()/deliver()`, `AlertHistory::set_muted/is_muted`. The TUI mutes via `[m]`. The pidfile is state about hermon itself, not the agents — the engine's read-only-stores principle is untouched.
- `menubar` enables notifications by default (same `NotifyCfg` flags as `watch`).
- `watch` detects a running `hermon menubar` and defaults ITS notifications off, printing a one-line notice ("menubar instance is notifying; pass --notify to override"). Detection mechanism: a pidfile-with-liveness-check in the user runtime dir (use the `dirs` crate — already a dep — for the path): write pid on menubar start, remove on exit, stale pid → not running.
- Explicit flags always win: `watch --notify` forces on, `menubar --no-notify` forces off.
- "Mute notifications" toggle in the dropdown (checkmark item, via #71's menu structure) wired to the same mute as the TUI's `[m]` (`AlertHistory::set_muted`); icon reflects muted state (e.g. dimmed/struck variant or `🔕` suffix).
- Icon flips to an attention variant while any ⏸/⚠ exists (redundant with the count text, but it's what peripheral vision catches) — drive from the same `Liveness` counts #70 computes.
Seam note (critical — #77 extends this): design the pidfile check as a small standalone module/functions (e.g. in notify.rs or a new arbitration helper) parameterized by UI kind, not hardcoded "menubar vs watch" — #77 adds `gui` as a third participant with precedence menubar > gui > watch. Keep the API additive and unit-testable with an injected runtime-dir path (no real /var/run in tests). Do not change existing `NotifyCfg` field meanings; add defaults-resolution logic around it.

**Out of scope**
Cross-process mute sync (muting in the TUI does not mute the menubar — document it; revisit only if it annoys in practice).

**Acceptance criteria**
- Test for the pidfile liveness check (stale pid, live pid, missing file).
- Live check in the PR: menubar running + `watch` started → exactly ONE banner per event; `watch --notify` → two (proving the override); mute toggle silences and the icon shows it.
- `cargo test` + CI green.