### PR TITLE
gui: live session panes with LayoutJob, follow-scroll, zoom

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -15,10 +15,11 @@
 //! [`view::apply`] and never orders them itself.
 
 pub mod palette;
+pub mod pane;
 pub mod roster;
 
 use std::collections::{HashMap, VecDeque};
-use std::sync::mpsc::{self, Receiver};
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 
 use anyhow::anyhow;
@@ -29,14 +30,18 @@ use crate::engine::{Engine, Event, Lifecycle, UiCmd};
 use crate::render::StyledLine;
 use crate::roster::RosterRow;
 use crate::source::Liveness;
-use crate::view::ViewState;
-
-/// Transcript lines kept per open pane, as in [`crate::ui`]: far more than
-/// any viewport shows, since the surplus is what #76's scrollback reads.
-const PANE_SCROLLBACK: usize = 5_000;
+use crate::ui::pane::SCROLLBACK;
+use crate::view::{self, ViewState};
 
 const WINDOW_SIZE: [f32; 2] = [900.0, 620.0];
 const MIN_WINDOW_SIZE: [f32; 2] = [480.0, 320.0];
+/// How much of the window the pane area starts with, and the least it can be
+/// dragged down to.
+const PANE_AREA_HEIGHT: f32 = 300.0;
+const PANE_AREA_MIN: f32 = 80.0;
+
+/// A pane whose session has produced no transcript yet.
+static NO_LINES: VecDeque<StyledLine> = VecDeque::new();
 
 /// Opens the window and blocks until it closes, then shuts the engine down
 /// and joins it.
@@ -48,6 +53,7 @@ pub fn run_gui(config: EngineConfig) -> anyhow::Result<()> {
         config.hermes_db.clone(),
         config.opencode_db.clone(),
     ];
+    let max_panes = config.max_panes;
     let (event_tx, event_rx) = mpsc::channel();
     let (cmd_tx, cmd_rx) = mpsc::channel();
     let engine = Engine::spawn(config, event_tx, cmd_rx);
@@ -60,13 +66,19 @@ pub fn run_gui(config: EngineConfig) -> anyhow::Result<()> {
         ..eframe::NativeOptions::default()
     };
     let mut event_rx = Some(event_rx);
+    let app_cmds = cmd_tx.clone();
     let result = eframe::run_native(
         "hermon",
         options,
         Box::new(move |cc| {
             palette::install(&cc.egui_ctx);
             let events = event_rx.take().expect("app creator runs once");
-            Ok(Box::new(App::new(wake(events, cc.egui_ctx.clone()), paths)))
+            Ok(Box::new(App::new(
+                wake(events, cc.egui_ctx.clone()),
+                app_cmds,
+                paths,
+                max_panes,
+            )))
         }),
     );
 
@@ -108,11 +120,12 @@ pub struct App {
     pub roster: Vec<RosterRow>,
     pub ticker: Vec<StyledLine>,
     /// The selected session's [`RosterRow::id`], not its row number: the
-    /// roster re-sorts by activity every tick. Nothing sets it yet — #75
-    /// owns the cursor.
+    /// roster re-sorts by activity every tick. #75's table sets it; the pane
+    /// under the table follows it.
     pub selected_id: Option<String>,
-    /// Transcript lines per open pane, oldest first. Filled once #76 opens
-    /// panes; until then the engine tails nothing and this stays empty.
+    /// Transcript lines per open pane, oldest first. Only open panes have an
+    /// entry: closing one drops its buffer, so reopening shows the engine's
+    /// fresh replay instead of it twice.
     pub panes: HashMap<String, VecDeque<StyledLine>>,
     /// The active sort, filter and attention-first flag (#40's pure core),
     /// which #75's header clicks and #77's controls drive.
@@ -120,6 +133,21 @@ pub struct App {
     /// The store paths the engine is watching, for the empty state —
     /// [`crate::ui::App::paths`]'s desktop twin.
     pub paths: Vec<String>,
+    /// Whether the pane area tiles every session with a slot, rather than
+    /// just the selected one.
+    pub grid: bool,
+    /// Whether the selected pane has the window to itself.
+    pub zoomed: bool,
+    /// The engine's `--max-panes` ceiling: the grid never asks it to tail
+    /// more than it would keep.
+    pub max_panes: usize,
+    /// Follow-scroll and wrap state per pane, keyed like [`App::panes`].
+    pane_views: HashMap<String, pane::PaneView>,
+    /// The keys whose tailers the engine currently holds open — tracked
+    /// separately from the selection so a roster reorder that changes nothing
+    /// visible does not churn them.
+    open_panes: Vec<String>,
+    cmds: Sender<UiCmd>,
     events: Receiver<Event>,
     /// The title last pushed to the window, so an unchanged one costs no
     /// viewport command.
@@ -127,7 +155,12 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(events: Receiver<Event>, paths: Vec<String>) -> Self {
+    pub fn new(
+        events: Receiver<Event>,
+        cmds: Sender<UiCmd>,
+        paths: Vec<String>,
+        max_panes: usize,
+    ) -> Self {
         App {
             roster: Vec::new(),
             ticker: Vec::new(),
@@ -135,6 +168,12 @@ impl App {
             panes: HashMap::new(),
             view: ViewState::default(),
             paths,
+            grid: false,
+            zoomed: false,
+            max_panes,
+            pane_views: HashMap::new(),
+            open_panes: Vec::new(),
+            cmds,
             events,
             title: Self::default_title(),
         }
@@ -185,9 +224,7 @@ impl App {
     /// frozen forever, or replay its history twice.
     fn apply_lifecycle(&mut self, key: &str, change: Lifecycle) {
         match change {
-            Lifecycle::Evicted | Lifecycle::Resumed => {
-                self.panes.remove(key);
-            }
+            Lifecycle::Evicted | Lifecycle::Resumed => self.drop_pane(key),
             Lifecycle::Started
             | Lifecycle::Finished(_)
             | Lifecycle::Attention(_)
@@ -196,21 +233,199 @@ impl App {
     }
 
     /// Appends a fast tick's lines to a pane's buffer, dropping the oldest
-    /// past [`PANE_SCROLLBACK`].
+    /// past [`SCROLLBACK`]. Lines for any other key are stale — in flight
+    /// when the pane closed — and discarded.
     fn buffer_pane(&mut self, key: &str, lines: Vec<StyledLine>) {
+        if !self.open_panes.iter().any(|open| open == key) {
+            return;
+        }
+        let arrived = lines.len();
         let buffer = self.panes.entry(key.to_string()).or_default();
         buffer.extend(lines);
-        while buffer.len() > PANE_SCROLLBACK {
+        while buffer.len() > SCROLLBACK {
             buffer.pop_front();
+        }
+        // The pane's wrap is cached, and a paused pane counts what it is not
+        // showing: both live on the view, which the writer keeps honest.
+        let view = self.pane_views.entry(key.to_string()).or_default();
+        view.invalidate();
+        view.follow.appended(arrived);
+    }
+
+    fn drop_pane(&mut self, key: &str) {
+        self.panes.remove(key);
+        self.pane_views.remove(key);
+    }
+
+    /// The sessions the engine should be tailing: the selected one, or in
+    /// grid mode every session with a slot, capped at the `--max-panes` the
+    /// engine would keep open anyway.
+    fn wanted_panes(&self) -> Vec<String> {
+        if !self.grid {
+            return self.selected_key().into_iter().collect();
+        }
+        view::apply(&self.roster, &self.view)
+            .rows
+            .iter()
+            .take(self.max_panes)
+            .map(|row| row.key.clone())
+            .collect()
+    }
+
+    /// Brings the engine's open tailers in line with what the window shows,
+    /// through the same [`UiCmd`]s the TUI sends. A pane that loses its slot
+    /// is closed and its buffer dropped, since the engine replays history on
+    /// reopen and the stale tail would show twice.
+    fn sync_panes(&mut self) {
+        let wanted = self.wanted_panes();
+        if wanted == self.open_panes {
+            return;
+        }
+        for old in &self.open_panes {
+            if !wanted.contains(old) {
+                self.panes.remove(old);
+                self.pane_views.remove(old);
+                let _ = self.cmds.send(UiCmd::ClosePane(old.clone()));
+            }
+        }
+        for new in &wanted {
+            if !self.open_panes.contains(new) {
+                let _ = self.cmds.send(UiCmd::OpenPane(new.clone()));
+            }
+        }
+        self.open_panes = wanted;
+    }
+
+    /// The selected session's row, or `None` while the roster is empty or
+    /// the filter hides it.
+    pub fn selected_row(&self) -> Option<&RosterRow> {
+        let id = self.selected_id.as_deref()?;
+        view::apply(&self.roster, &self.view)
+            .rows
+            .into_iter()
+            .find(|row| row.id == id)
+    }
+
+    fn selected_key(&self) -> Option<String> {
+        self.selected_row().map(|row| row.key.clone())
+    }
+
+    /// The keyboard half of the pane controls: zoom in and out, and park the
+    /// selected pane at the top of its scrollback or back on its tail. #77
+    /// owns the rest of the key map.
+    fn handle_keys(&mut self, ctx: &egui::Context) {
+        if ctx.egui_wants_keyboard_input() {
+            return;
+        }
+        let (escape, enter, top, tail) = ctx.input(|input| {
+            (
+                input.key_pressed(egui::Key::Escape),
+                input.key_pressed(egui::Key::Enter),
+                input.key_pressed(egui::Key::G) && !input.modifiers.shift,
+                input.key_pressed(egui::Key::G) && input.modifiers.shift,
+            )
+        });
+        if escape {
+            self.zoomed = false;
+        }
+        if enter && self.selected_row().is_some() {
+            self.zoomed = true;
+        }
+        if let Some(key) = self.selected_key().filter(|_| top || tail) {
+            let view = self.pane_views.entry(key).or_default();
+            if top {
+                view.jump_top();
+            } else {
+                view.jump_latest();
+            }
         }
     }
 
-    /// The body: the fleet table, real widgets and all — [`roster::render`]
-    /// owns the layout, this stays a thin call so the update path is still
-    /// one function ([`App::apply_event`]) tests can drive without a window.
+    /// The body: the fleet table with the pane area under it, or a single
+    /// zoomed pane with the window to itself.
     fn draw(&mut self, ui: &mut egui::Ui) {
-        roster::render(ui, self);
+        self.handle_keys(ui.ctx());
+        if self.zoomed && self.selected_row().is_some() {
+            self.draw_panes(ui);
+        } else {
+            self.zoomed = false;
+            egui::Panel::bottom("hermon-panes")
+                .resizable(true)
+                .default_size(PANE_AREA_HEIGHT)
+                .min_size(PANE_AREA_MIN)
+                .show(ui, |ui| self.draw_panes(ui));
+            egui::CentralPanel::default().show(ui, |ui| roster::render(ui, self));
+        }
+        self.sync_panes();
     }
+
+    /// The pane area: one pane for the selected session, or a tile per open
+    /// session in grid mode. Zoom collapses either back to the selected one.
+    fn draw_panes(&mut self, ui: &mut egui::Ui) {
+        let keys: Vec<String> = if self.grid && !self.zoomed {
+            self.open_panes.clone()
+        } else {
+            self.selected_key().into_iter().collect()
+        };
+        if keys.is_empty() {
+            ui.label(egui::RichText::new("no session selected").color(palette::DIM));
+            return;
+        }
+
+        let cells = tile(ui.available_rect_before_wrap(), keys.len());
+        for (key, cell) in keys.iter().zip(cells) {
+            let action = ui
+                .scope_builder(egui::UiBuilder::new().max_rect(cell), |ui| {
+                    self.draw_pane(ui, key)
+                })
+                .inner;
+            if action.clicked || action.double_clicked {
+                self.selected_id = self
+                    .roster
+                    .iter()
+                    .find(|row| &row.key == key)
+                    .map(|row| row.id.clone());
+            }
+            if action.double_clicked {
+                self.zoomed = !self.zoomed;
+            }
+        }
+    }
+
+    /// One session's pane. Its row carries the chrome (model, state, pinned),
+    /// its buffer the transcript, its view the scroll state — three maps that
+    /// stay disjoint so the draw can borrow them all at once.
+    fn draw_pane(&mut self, ui: &mut egui::Ui, key: &str) -> pane::PaneAction {
+        let Some(row) = self.roster.iter().find(|row| row.key == key) else {
+            return pane::PaneAction::default();
+        };
+        let widget = pane::Pane {
+            key: &row.key,
+            model: &row.model,
+            state: row.state,
+            selected: self.selected_id.as_deref() == Some(row.id.as_str()),
+            pinned: self.view.is_pinned(&row.id),
+            attn_elapsed: row.attn_elapsed,
+            lines: self.panes.get(&row.key).unwrap_or(&NO_LINES),
+        };
+        let view = self.pane_views.entry(row.key.clone()).or_default();
+        pane::render(ui, &widget, view)
+    }
+}
+
+/// `n` equal cells filling `area`, in the tiling the artboards call for: one
+/// fills it, two split it, four make a square, six go three across.
+fn tile(area: egui::Rect, n: usize) -> Vec<egui::Rect> {
+    let cols = (n as f32).sqrt().ceil().max(1.0);
+    let rows = (n as f32 / cols).ceil().max(1.0);
+    let size = egui::vec2(area.width() / cols, area.height() / rows);
+    (0..n)
+        .map(|i| {
+            let x = (i % cols as usize) as f32;
+            let y = (i / cols as usize) as f32;
+            egui::Rect::from_min_size(area.min + egui::vec2(x * size.x, y * size.y), size)
+        })
+        .collect()
 }
 
 impl eframe::App for App {
@@ -264,7 +479,15 @@ mod tests {
 
     fn app() -> (Sender<Event>, App) {
         let (tx, rx) = mpsc::channel();
-        (tx, App::new(rx, Vec::new()))
+        let (cmds, _) = mpsc::channel();
+        (tx, App::new(rx, cmds, Vec::new(), 6))
+    }
+
+    /// An app whose engine commands can be read back, for the pane tests.
+    fn app_with_cmds() -> (Sender<Event>, Receiver<UiCmd>, App) {
+        let (tx, rx) = mpsc::channel();
+        let (cmds, cmd_rx) = mpsc::channel();
+        (tx, cmd_rx, App::new(rx, cmds, Vec::new(), 6))
     }
 
     /// One egui pass with no window behind it. The output carries texture
@@ -307,9 +530,19 @@ mod tests {
         assert_eq!(app.live_count(), 0);
     }
 
+    /// An app with one selected session whose pane the engine has been asked
+    /// to tail — the state every pane test starts from.
+    fn app_with_pane(key: &str) -> App {
+        let (_tx, mut app) = app();
+        app.apply_event(Event::Roster(vec![row(key, Liveness::Live)]));
+        app.selected_id = Some(format!("{key}-id"));
+        app.sync_panes();
+        app
+    }
+
     #[test]
     fn pane_lines_buffer_and_lifecycle_drops_them() {
-        let (_tx, mut app) = app();
+        let mut app = app_with_pane("C:aaa");
         app.apply_event(Event::PaneLines {
             key: "C:aaa".to_string(),
             lines: vec![StyledLine::default(), StyledLine::default()],
@@ -330,14 +563,102 @@ mod tests {
         assert!(!app.panes.contains_key("C:aaa"));
     }
 
+    /// Lines for a pane nobody opened were in flight when it closed: taking
+    /// them would leave a buffer no one ever draws or drops.
     #[test]
-    fn pane_buffer_is_capped_at_scrollback() {
+    fn lines_for_a_closed_pane_are_discarded() {
         let (_tx, mut app) = app();
         app.apply_event(Event::PaneLines {
             key: "C:aaa".to_string(),
-            lines: vec![StyledLine::default(); PANE_SCROLLBACK + 10],
+            lines: vec![StyledLine::default()],
         });
-        assert_eq!(app.panes["C:aaa"].len(), PANE_SCROLLBACK);
+        assert!(!app.panes.contains_key("C:aaa"));
+    }
+
+    #[test]
+    fn pane_buffer_is_capped_at_scrollback() {
+        let mut app = app_with_pane("C:aaa");
+        app.apply_event(Event::PaneLines {
+            key: "C:aaa".to_string(),
+            lines: vec![StyledLine::default(); SCROLLBACK + 10],
+        });
+        assert_eq!(app.panes["C:aaa"].len(), SCROLLBACK);
+    }
+
+    /// The cursor is what the engine tails: selecting a session opens its
+    /// pane, moving off it closes the old one and opens the new, and the
+    /// closed pane's buffer goes with it.
+    #[test]
+    fn the_selection_drives_the_engine_s_tailers() {
+        let (tx, cmds, mut app) = app_with_cmds();
+        tx.send(Event::Roster(vec![
+            row("C:aaa", Liveness::Live),
+            row("H:bbb", Liveness::Live),
+        ]))
+        .unwrap();
+        app.drain();
+
+        app.selected_id = Some("C:aaa-id".to_string());
+        app.sync_panes();
+        assert_eq!(
+            cmds.try_iter().collect::<Vec<_>>(),
+            vec![UiCmd::OpenPane("C:aaa".to_string())]
+        );
+        app.apply_event(Event::PaneLines {
+            key: "C:aaa".to_string(),
+            lines: vec![StyledLine::default()],
+        });
+
+        app.selected_id = Some("H:bbb-id".to_string());
+        app.sync_panes();
+        assert_eq!(
+            cmds.try_iter().collect::<Vec<_>>(),
+            vec![
+                UiCmd::ClosePane("C:aaa".to_string()),
+                UiCmd::OpenPane("H:bbb".to_string()),
+            ]
+        );
+        assert!(
+            !app.panes.contains_key("C:aaa"),
+            "a closed pane's buffer goes with it, or the engine's replay shows twice"
+        );
+    }
+
+    /// Grid mode tails every session with a slot, never more than the engine
+    /// would keep open under `--max-panes`.
+    #[test]
+    fn grid_mode_opens_every_slot_up_to_max_panes() {
+        let (_tx, cmds, mut app) = app_with_cmds();
+        let keys = ["C:aaa", "H:bbb", "O:ccc", "C:ddd"];
+        app.apply_event(Event::Roster(
+            keys.iter().map(|k| row(k, Liveness::Live)).collect(),
+        ));
+        app.max_panes = 3;
+        app.grid = true;
+        app.sync_panes();
+
+        let opened: Vec<UiCmd> = cmds.try_iter().collect();
+        assert_eq!(opened.len(), 3, "{opened:?}");
+        for key in &keys[..3] {
+            assert!(opened.contains(&UiCmd::OpenPane(key.to_string())), "{key}");
+        }
+    }
+
+    /// A paused pane counts what it is not showing; the buffer's writer is
+    /// what keeps the badge honest.
+    #[test]
+    fn lines_arriving_behind_a_paused_pane_feed_the_badge() {
+        let mut app = app_with_pane("C:aaa");
+        app.pane_views
+            .entry("C:aaa".to_string())
+            .or_default()
+            .follow
+            .observe(false);
+        app.apply_event(Event::PaneLines {
+            key: "C:aaa".to_string(),
+            lines: vec![StyledLine::default(); 4],
+        });
+        assert_eq!(app.pane_views["C:aaa"].follow.unseen, 4);
     }
 
     /// The repaint discipline, headless: a quiet fleet stops asking for
@@ -347,7 +668,8 @@ mod tests {
     fn a_quiet_window_settles_and_an_engine_event_wakes_it() {
         let ctx = egui::Context::default();
         let (tx, engine_rx) = mpsc::channel();
-        let mut app = App::new(wake(engine_rx, ctx.clone()), Vec::new());
+        let (cmds, _cmd_rx) = mpsc::channel();
+        let mut app = App::new(wake(engine_rx, ctx.clone()), cmds, Vec::new(), 6);
         app.apply_event(Event::Roster(vec![row("C:aaa", Liveness::Live)]));
 
         // A fresh context takes a pass or two to settle (fonts, first
@@ -393,6 +715,73 @@ mod tests {
             row("H:bbb", Liveness::Attention(Attn::Stuck)),
         ]));
         pass(&ctx, |ui| app.draw(ui));
+    }
+
+    /// The three body layouts — a pane under the table, a grid of tiles, and
+    /// one zoomed pane with the window to itself — all lay out headless.
+    #[test]
+    fn the_pane_area_draws_selected_grid_and_zoomed() {
+        let (_tx, mut app) = app();
+        let ctx = egui::Context::default();
+        app.apply_event(Event::Roster(vec![
+            row("C:aaa", Liveness::Live),
+            row("H:bbb", Liveness::Attention(Attn::Stuck)),
+            row("O:ccc", Liveness::Done),
+        ]));
+        app.selected_id = Some("C:aaa-id".to_string());
+        app.sync_panes();
+        app.apply_event(Event::PaneLines {
+            key: "C:aaa".to_string(),
+            lines: vec![StyledLine::default(); 20],
+        });
+        pass(&ctx, |ui| app.draw(ui));
+
+        app.grid = true;
+        app.sync_panes();
+        pass(&ctx, |ui| app.draw(ui));
+
+        app.zoomed = true;
+        pass(&ctx, |ui| app.draw(ui));
+        assert!(app.zoomed, "a zoom with a selection survives the frame");
+    }
+
+    /// Zoom needs something to zoom: with no selection it collapses back
+    /// rather than leaving the window blank.
+    #[test]
+    fn zoom_without_a_selection_falls_back_to_the_table() {
+        let (_tx, mut app) = app();
+        let ctx = egui::Context::default();
+        app.zoomed = true;
+        pass(&ctx, |ui| app.draw(ui));
+        assert!(!app.zoomed);
+    }
+
+    /// `Enter` zooms the selected pane and `Esc` comes back, through the
+    /// same `ctx.input` path #77 extends.
+    #[test]
+    fn enter_zooms_and_escape_returns() {
+        let (_tx, mut app) = app();
+        let ctx = egui::Context::default();
+        app.apply_event(Event::Roster(vec![row("C:aaa", Liveness::Live)]));
+        app.selected_id = Some("C:aaa-id".to_string());
+
+        let key = |key: egui::Key| egui::RawInput {
+            events: vec![egui::Event::Key {
+                key,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::default(),
+            }],
+            ..egui::RawInput::default()
+        };
+        let mut out = ctx.run_ui(key(egui::Key::Enter), |ui| app.draw(ui));
+        out.textures_delta.clear();
+        assert!(app.zoomed);
+
+        let mut out = ctx.run_ui(key(egui::Key::Escape), |ui| app.draw(ui));
+        out.textures_delta.clear();
+        assert!(!app.zoomed);
     }
 
     #[test]

--- a/src/gui/pane.rs
+++ b/src/gui/pane.rs
@@ -1,0 +1,719 @@
+//! A live session's pane: the streaming transcript, its follow-scroll state
+//! machine, and the chrome around both — the desktop twin of
+//! [`crate::ui::pane`].
+//!
+//! Three decisions shape this module.
+//!
+//! Text is drawn as one [`LayoutJob`] per display line, each [`Seg`] a styled
+//! section in the shared [`Sem`] color. Nothing about a renderer's output
+//! changes on the way here.
+//!
+//! Wrapping is [`crate::ui::pane::wrap_styled`]'s, not the layout job's. The
+//! pane is monospaced, so breaking on character columns is exact, and it buys
+//! two things a job-wrapped pane cannot have: display lines of uniform
+//! height, which is what lets [`egui::ScrollArea::show_rows`] lay out only
+//! the ~40 rows on screen instead of all 5000 in the buffer, and breaks in
+//! the same places the TUI puts them. Measured on a 5000-line buffer, that is
+//! ~0.3 ms a frame against ~2 ms for laying every line out. The wrap is
+//! cached per pane and recomputed only when the buffer changes or the pane
+//! is resized.
+//!
+//! Follow-scroll is tracked here rather than left to `stick_to_bottom`.
+//! egui's stickiness is private state that only re-arms when the offset lands
+//! exactly on the end, so a "jump to latest" button has nothing to press.
+//! Instead [`PaneView`] remembers the bottom offset each frame and drives the
+//! scroll area to it while following; a wheel or drag moves the offset off
+//! the bottom, [`Follow::observe`] sees that and pauses, and the badge counts
+//! what arrives meanwhile. The transitions are plain data, so #77's `g`/`G`
+//! keys are two method calls rather than a rewrite.
+
+use std::collections::VecDeque;
+
+use eframe::egui::text::LayoutJob;
+use eframe::egui::{
+    self, Align, Color32, FontId, Layout, Rect, RichText, Sense, Stroke, TextFormat, TextStyle, Ui,
+    Vec2,
+};
+
+use crate::render::{Sem, StyledLine};
+use crate::source::Liveness;
+use crate::ui::pane::{attention_status, wrap_styled};
+
+use super::palette;
+
+/// Frames a jump to the tail holds the pane there regardless of where the
+/// scroll area ended up. egui keeps applying a wheel's momentum for a few
+/// frames after the wheel itself stopped, and that leftover must not read as
+/// the user immediately scrolling away again.
+const SETTLE_FRAMES: u8 = 4;
+
+/// A session's pane: everything the widget needs about it that is not scroll
+/// state. Borrowed straight from the app's roster row and buffer.
+pub struct Pane<'a> {
+    pub key: &'a str,
+    pub model: &'a str,
+    pub state: Liveness,
+    pub selected: bool,
+    pub pinned: bool,
+    /// Seconds in the current attention state, for the inline status line.
+    pub attn_elapsed: Option<f64>,
+    /// The session's transcript buffer, oldest first.
+    pub lines: &'a VecDeque<StyledLine>,
+}
+
+/// Whether a pane is following its tail, and how much it has missed since it
+/// stopped. The pure core of the scroll behaviour: every transition is a
+/// method, so the draw code only reports what the user did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Follow {
+    pub following: bool,
+    /// Lines that arrived since following stopped — the `▼ N new` badge.
+    pub unseen: usize,
+}
+
+impl Default for Follow {
+    fn default() -> Self {
+        Follow {
+            following: true,
+            unseen: 0,
+        }
+    }
+}
+
+impl Follow {
+    /// `n` lines appended to the buffer. A followed pane shows them, so only
+    /// a paused one has anything to count.
+    pub fn appended(&mut self, n: usize) {
+        if !self.following {
+            self.unseen = self.unseen.saturating_add(n);
+        }
+    }
+
+    /// Where the scroll area ended up this frame. Scrolling away pauses the
+    /// follow; scrolling back to the bottom resumes it, exactly as clicking
+    /// the badge does.
+    pub fn observe(&mut self, at_bottom: bool) {
+        match (self.following, at_bottom) {
+            (true, false) => self.following = false,
+            (false, true) => *self = Follow::default(),
+            _ => {}
+        }
+    }
+
+    /// "Jump to latest" — the badge click, and #77's `G`.
+    pub fn resume(&mut self) {
+        *self = Follow::default();
+    }
+}
+
+/// A pane's scroll state across frames: its follow flag, the wrapped
+/// transcript it is showing, and the geometry needed to drive the scroll area
+/// to the bottom without asking egui where the bottom is.
+#[derive(Debug, Default)]
+pub struct PaneView {
+    pub follow: Follow,
+    /// The buffer wrapped to `cols`, plus the attention status line.
+    wrapped: Vec<StyledLine>,
+    cols: usize,
+    /// Set when the buffer changed under us, so the wrap is recomputed once
+    /// rather than every frame.
+    dirty: bool,
+    /// Last frame's bottom offset and row count, which together give this
+    /// frame's bottom offset: the content grows by exactly one row height per
+    /// new row.
+    bottom: Option<f32>,
+    rows: usize,
+    /// An offset to jump to next frame, from `g`/`G` or the badge.
+    pending: Option<f32>,
+    /// Frames left of [`SETTLE_FRAMES`] after a jump to the tail.
+    settling: u8,
+}
+
+impl PaneView {
+    /// The buffer changed: re-wrap before the next draw.
+    pub fn invalidate(&mut self) {
+        self.dirty = true;
+    }
+
+    /// Scrolls to the top and stops following, the desktop's `g`.
+    pub fn jump_top(&mut self) {
+        self.follow.following = false;
+        self.pending = Some(0.0);
+    }
+
+    /// Back to the tail, the desktop's `G` and what the badge does. No
+    /// explicit offset: following recomputes the bottom every frame, and the
+    /// one measured here is already stale by the rows that arrived since.
+    pub fn jump_latest(&mut self) {
+        self.follow.resume();
+        self.pending = None;
+        self.settling = SETTLE_FRAMES;
+    }
+
+    /// The display lines for a `cols`-wide pane, re-wrapping only when the
+    /// buffer or the width changed.
+    fn reflow(&mut self, pane: &Pane, cols: usize) -> &[StyledLine] {
+        if self.dirty || self.cols != cols {
+            let mut wrapped = wrap_styled(pane.lines, cols);
+            if let Some(status) = attention_status(pane.state, pane.attn_elapsed) {
+                wrapped.extend(wrap_styled(&VecDeque::from([status]), cols));
+            }
+            self.wrapped = wrapped;
+            self.cols = cols;
+            self.dirty = false;
+        }
+        &self.wrapped
+    }
+}
+
+/// What the user did to a pane this frame, for the caller to act on: a click
+/// selects the session, a double click zooms it.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PaneAction {
+    pub clicked: bool,
+    pub double_clicked: bool,
+}
+
+/// Draws the pane — border, title, transcript and badge — into the space
+/// `ui` has left, and reports what the user did to it.
+pub fn render(ui: &mut Ui, pane: &Pane, view: &mut PaneView) -> PaneAction {
+    // Claimed before the contents are drawn, not after: egui gives a
+    // contested click to the last widget registered, so the badge inside has
+    // to come after this or it would never be clickable.
+    let response = ui.interact(
+        ui.available_rect_before_wrap(),
+        ui.id().with(("pane", pane.key)),
+        Sense::click(),
+    );
+
+    let stroke = Stroke::new(1.0, border_color(pane));
+    egui::Frame::NONE
+        .stroke(stroke)
+        .inner_margin(6.0)
+        .corner_radius(4.0)
+        .show(ui, |ui| {
+            title_bar(ui, pane);
+            transcript(ui, pane, view);
+        });
+
+    PaneAction {
+        clicked: response.clicked(),
+        double_clicked: response.double_clicked(),
+    }
+}
+
+/// `✓ C:0f865f — sonnet-4.5`: the state glyph a finished session carries in
+/// the roster too, its key, and the model it is running.
+fn title_bar(ui: &mut Ui, pane: &Pane) {
+    let color = border_color(pane);
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 4.0;
+        if pane.state == Liveness::Done {
+            let (glyph, glyph_color) = palette::glyph_for_liveness(pane.state);
+            ui.label(RichText::new(glyph).color(glyph_color).monospace());
+        }
+        ui.label(RichText::new(pane.key).color(color).monospace().strong());
+        ui.label(
+            RichText::new(format!("\u{2014} {}", pane.model))
+                .color(palette::DIM)
+                .monospace(),
+        );
+    });
+}
+
+/// The scrolling transcript, plus the `▼ N new` badge when it is paused.
+fn transcript(ui: &mut Ui, pane: &Pane, view: &mut PaneView) {
+    // Transcript rows sit flush, like a terminal's. This also keeps the row
+    // pitch a single number: `show_rows` reserves `row_height` per row and
+    // the rows drawn inside take exactly that.
+    ui.spacing_mut().item_spacing.y = 0.0;
+    let font = TextStyle::Monospace.resolve(ui.style());
+    let (row_height, col_width) =
+        ui.fonts_mut(|fonts| (fonts.row_height(&font), fonts.glyph_width(&font, ' ')));
+    // The scrollbar eats into the text width; wrapping past it would leave a
+    // column of clipped characters.
+    let width = ui.available_width() - ui.spacing().scroll.bar_width;
+    let cols = (width / col_width).floor().max(1.0) as usize;
+
+    let settling = view.settling > 0;
+    view.settling = view.settling.saturating_sub(1);
+    let rows = view.reflow(pane, cols).len();
+    let offset = view.pending.take().or_else(|| {
+        // Following: the bottom of the content, which is last frame's bottom
+        // plus a row per row that has arrived since.
+        view.follow.following.then_some(())?;
+        let grown = rows.saturating_sub(view.rows) as f32;
+        Some(view.bottom? + grown * row_height)
+    });
+
+    let mut area = egui::ScrollArea::vertical()
+        .id_salt(("pane-scroll", pane.key))
+        .auto_shrink([false, false])
+        // Only load-bearing before the first frame has measured the pane:
+        // after that `offset` above drives the tail explicitly.
+        .stick_to_bottom(view.follow.following);
+    if let Some(offset) = offset {
+        area = area.vertical_scroll_offset(offset);
+    }
+
+    let out = area.show_rows(ui, row_height, rows, |ui, range| {
+        for line in &view.wrapped[range] {
+            ui.label(job(line, &font));
+        }
+    });
+
+    let bottom = (out.content_size.y - out.inner_rect.height()).max(0.0);
+    if settling {
+        // Still shaking off the wheel that paused it; the tail is where the
+        // jump asked to be, whatever the offset says this frame.
+        ui.ctx().request_repaint();
+    } else {
+        // Within a line of the bottom is the bottom: egui eases the offset
+        // into place over several frames, and that must not read as the user
+        // scrolling away. A wheel tick moves several rows, so a real scroll
+        // still registers on the frame it happens.
+        view.follow
+            .observe(out.state.offset.y >= bottom - row_height);
+    }
+    view.bottom = Some(bottom);
+    view.rows = rows;
+
+    if !view.follow.following && badge(ui, out.inner_rect, view.follow.unseen) {
+        view.jump_latest();
+    }
+}
+
+/// The floating jump-to-latest button over the bottom-right of the
+/// transcript; `true` when it was clicked. It paints over the last line
+/// rather than taking a row of its own, as the TUI's `▼ N more` does, and it
+/// is the whole affordance for resuming, so a paused pane with nothing new
+/// still gets one.
+fn badge(ui: &mut Ui, area: Rect, unseen: usize) -> bool {
+    let label = match unseen {
+        0 => "\u{25bc} latest".to_string(),
+        n => format!("\u{25bc} {n} new"),
+    };
+    let button = egui::Button::new(RichText::new(label).color(palette::BG).monospace())
+        .fill(palette::color(Sem::Stat))
+        .corner_radius(3.0);
+    let size = Vec2::new(90.0, 20.0);
+    let rect = Rect::from_min_size(area.max - size - Vec2::new(4.0, 4.0), size);
+    ui.scope_builder(egui::UiBuilder::new().max_rect(rect), |ui| {
+        ui.with_layout(Layout::right_to_left(Align::BOTTOM), |ui| {
+            ui.add(button).clicked()
+        })
+        .inner
+    })
+    .inner
+}
+
+/// One display line as a layout job: a section per segment in its semantic
+/// color, monospaced, and never re-wrapped — [`wrap_styled`] already broke it
+/// to the pane's width.
+fn job(line: &StyledLine, font: &FontId) -> LayoutJob {
+    let mut job = LayoutJob::default();
+    job.wrap.max_width = f32::INFINITY;
+    for seg in &line.0 {
+        job.append(
+            &seg.text,
+            0.0,
+            TextFormat {
+                font_id: font.clone(),
+                color: palette::color(seg.sem),
+                ..TextFormat::default()
+            },
+        );
+    }
+    job
+}
+
+/// The border and title tint, mirroring [`crate::ui::pane::border_style`]:
+/// cyan for the selected pane, then the session's own state — amber waiting
+/// on you, red stuck, dim finished, plain chrome while it works — with a
+/// pinned finished pane staying amber rather than going dim.
+fn border_color(pane: &Pane) -> Color32 {
+    if pane.selected {
+        return palette::color(Sem::Stat);
+    }
+    match pane.state {
+        Liveness::Live => palette::BORDER,
+        Liveness::Attention(crate::source::Attn::PermWait) => palette::color(Sem::User),
+        Liveness::Attention(crate::source::Attn::Stuck) => palette::color(Sem::Error),
+        Liveness::Done if pane.pinned => palette::color(Sem::User),
+        Liveness::Done => palette::color(Sem::Dim),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::Seg;
+    use crate::source::Attn;
+
+    fn buffer(n: usize) -> VecDeque<StyledLine> {
+        (0..n)
+            .map(|i| {
+                StyledLine(vec![
+                    Seg::new(Sem::Tool, format!("Bash{i:04} ")),
+                    Seg::new(Sem::Dim, "ls -la /some/long/path --with-flags"),
+                ])
+            })
+            .collect()
+    }
+
+    fn pane(lines: &VecDeque<StyledLine>) -> Pane<'_> {
+        Pane {
+            key: "C:aaaaaa",
+            model: "sonnet-4.5",
+            state: Liveness::Live,
+            selected: false,
+            pinned: false,
+            attn_elapsed: None,
+            lines,
+        }
+    }
+
+    /// One egui pass with no window behind it, sized like a real pane.
+    fn pass(ctx: &egui::Context, mut body: impl FnMut(&mut Ui)) -> usize {
+        let mut out = ctx.run_ui(egui::RawInput::default(), |ui| {
+            ui.set_max_size(Vec2::new(600.0, 400.0));
+            body(ui);
+        });
+        out.textures_delta.clear();
+        out.shapes.len()
+    }
+
+    #[test]
+    fn a_fresh_pane_follows_its_tail_with_no_badge() {
+        let follow = Follow::default();
+        assert!(follow.following);
+        assert_eq!(follow.unseen, 0);
+    }
+
+    /// The whole state machine the seam note asks for: scrolling away pauses
+    /// the follow, lines arriving while paused feed the badge, and either
+    /// scrolling back or the badge itself resumes and clears it.
+    #[test]
+    fn scrolling_away_pauses_the_follow_and_counts_what_arrives() {
+        let mut follow = Follow::default();
+        follow.appended(5);
+        assert_eq!(follow.unseen, 0, "a followed pane misses nothing");
+
+        follow.observe(false);
+        assert!(!follow.following);
+        follow.appended(3);
+        follow.appended(2);
+        assert_eq!(follow.unseen, 5);
+
+        // Still away: more lines keep counting, the pane stays paused.
+        follow.observe(false);
+        assert!(!follow.following);
+        assert_eq!(follow.unseen, 5);
+
+        follow.resume();
+        assert_eq!(follow, Follow::default());
+    }
+
+    #[test]
+    fn scrolling_back_to_the_bottom_resumes_the_follow() {
+        let mut follow = Follow::default();
+        follow.observe(false);
+        follow.appended(7);
+        follow.observe(true);
+        assert_eq!(follow, Follow::default());
+    }
+
+    #[test]
+    fn a_re_wrap_only_happens_when_the_buffer_or_width_changes() {
+        let lines = buffer(3);
+        let filled = pane(&lines);
+        let empty = VecDeque::new();
+        let emptied = pane(&empty);
+        let mut view = PaneView {
+            dirty: true,
+            ..PaneView::default()
+        };
+        let wrapped = view.reflow(&filled, 20).len();
+        assert!(wrapped > 3, "40-odd columns of text must wrap to {wrapped}");
+
+        // Same width, no invalidation: the cache answers, buffer or not.
+        assert_eq!(view.reflow(&emptied, 20).len(), wrapped);
+        // A narrower pane re-wraps, and so does a buffer that changed.
+        assert_ne!(view.reflow(&filled, 10).len(), wrapped);
+        view.invalidate();
+        assert_eq!(view.reflow(&emptied, 10).len(), 0);
+    }
+
+    /// The attention status line rides at the end of the transcript, wrapped
+    /// with it, exactly as the TUI appends it.
+    #[test]
+    fn an_attention_pane_ends_with_its_status_line() {
+        let lines = buffer(1);
+        let waiting = Pane {
+            state: Liveness::Attention(Attn::PermWait),
+            attn_elapsed: Some(45.0),
+            ..pane(&lines)
+        };
+        let mut view = PaneView {
+            dirty: true,
+            ..PaneView::default()
+        };
+        let text: String = view
+            .reflow(&waiting, 80)
+            .iter()
+            .map(|l| l.to_plain())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            text.contains("waiting on permission prompt \u{b7} 45s"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn a_live_pane_has_no_status_line() {
+        let lines = buffer(1);
+        let mut view = PaneView {
+            dirty: true,
+            ..PaneView::default()
+        };
+        let text: String = view
+            .reflow(&pane(&lines), 80)
+            .iter()
+            .map(|l| l.to_plain())
+            .collect();
+        assert!(!text.contains("waiting on"), "{text}");
+    }
+
+    /// The performance claim, headless: a full 5000-line buffer must not put
+    /// 5000 lines' worth of shapes in the frame. Only the rows the viewport
+    /// can show are laid out at all.
+    #[test]
+    fn a_full_buffer_only_lays_out_the_visible_rows() {
+        let ctx = egui::Context::default();
+        let lines = buffer(crate::ui::pane::SCROLLBACK);
+        let mut view = PaneView {
+            dirty: true,
+            ..PaneView::default()
+        };
+        // First pass measures, second scrolls to the tail.
+        let shapes = {
+            pass(&ctx, |ui| {
+                render(ui, &pane(&lines), &mut view);
+            });
+            pass(&ctx, |ui| {
+                render(ui, &pane(&lines), &mut view);
+            })
+        };
+        assert!(
+            view.wrapped.len() >= crate::ui::pane::SCROLLBACK,
+            "the whole buffer is wrapped: {}",
+            view.wrapped.len()
+        );
+        assert!(
+            shapes < 500,
+            "a 400pt viewport must not paint {shapes} shapes"
+        );
+        assert!(view.follow.following, "a fresh pane follows its tail");
+    }
+
+    /// The follow state machine against egui's real scroll handling, with no
+    /// window: a wheel-up over the pane pauses the follow and the lines that
+    /// arrive next feed the badge, then jumping to the latest puts the pane
+    /// back on its tail.
+    #[test]
+    fn a_wheel_scroll_pauses_the_follow_and_a_jump_resumes_it() {
+        let ctx = egui::Context::default();
+        let mut lines = buffer(400);
+        let mut view = PaneView {
+            dirty: true,
+            ..PaneView::default()
+        };
+        fn frame(
+            ctx: &egui::Context,
+            input: egui::RawInput,
+            lines: &VecDeque<StyledLine>,
+            view: &mut PaneView,
+        ) {
+            let mut out = ctx.run_ui(input, |ui| {
+                ui.set_max_size(Vec2::new(600.0, 400.0));
+                render(ui, &pane(lines), view);
+            });
+            out.textures_delta.clear();
+        }
+
+        // Two settling frames: the first measures the pane, the second parks
+        // it on the tail.
+        frame(&ctx, egui::RawInput::default(), &lines, &mut view);
+        frame(&ctx, egui::RawInput::default(), &lines, &mut view);
+        assert!(view.follow.following, "a fresh pane follows");
+
+        let wheel = egui::RawInput {
+            events: vec![
+                egui::Event::PointerMoved(egui::pos2(300.0, 200.0)),
+                egui::Event::MouseWheel {
+                    unit: egui::MouseWheelUnit::Point,
+                    delta: Vec2::new(0.0, 120.0),
+                    phase: egui::TouchPhase::Move,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ],
+            ..egui::RawInput::default()
+        };
+        frame(&ctx, wheel, &lines, &mut view);
+        assert!(!view.follow.following, "scrolling up pauses the follow");
+
+        lines.push_back(StyledLine::default());
+        view.invalidate();
+        view.follow.appended(1);
+        frame(&ctx, egui::RawInput::default(), &lines, &mut view);
+        assert_eq!(view.follow.unseen, 1, "the badge counts what it hides");
+        assert!(!view.follow.following, "and the pane stays where it was");
+
+        // Jumping while the wheel's momentum is still decaying still lands
+        // on the tail and stays there.
+        view.jump_latest();
+        for _ in 0..6 {
+            frame(&ctx, egui::RawInput::default(), &lines, &mut view);
+        }
+        assert_eq!(view.follow, Follow::default(), "the jump lands on the tail");
+    }
+
+    /// Clicking the badge resumes the follow — and the pane-wide click
+    /// target, which covers the badge, must not swallow the click.
+    #[test]
+    fn clicking_the_badge_resumes_the_follow() {
+        let ctx = egui::Context::default();
+        let lines = buffer(400);
+        let mut view = PaneView {
+            follow: Follow {
+                following: false,
+                unseen: 9,
+            },
+            dirty: true,
+            ..PaneView::default()
+        };
+        let mut action = PaneAction::default();
+        let frame = |input: egui::RawInput, view: &mut PaneView, action: &mut PaneAction| {
+            let mut out = ctx.run_ui(input, |ui| {
+                ui.set_max_size(Vec2::new(600.0, 400.0));
+                *action = render(ui, &pane(&lines), view);
+            });
+            out.textures_delta.clear();
+        };
+        frame(egui::RawInput::default(), &mut view, &mut action);
+
+        // The badge sits in the bottom-right corner of the transcript, inside
+        // the pane's own frame margin and clear of the scrollbar.
+        let at = egui::pos2(600.0 - 6.0 - 4.0 - 45.0, 400.0 - 6.0 - 4.0 - 10.0);
+        let click = |pressed| egui::RawInput {
+            events: vec![
+                egui::Event::PointerMoved(at),
+                egui::Event::PointerButton {
+                    pos: at,
+                    button: egui::PointerButton::Primary,
+                    pressed,
+                    modifiers: egui::Modifiers::default(),
+                },
+            ],
+            ..egui::RawInput::default()
+        };
+        frame(click(true), &mut view, &mut action);
+        frame(click(false), &mut view, &mut action);
+
+        assert!(
+            view.follow.following,
+            "the badge puts the pane back on its tail"
+        );
+        assert_eq!(view.follow.unseen, 0);
+    }
+
+    /// Every pane state lays out without panicking, at sane and silly sizes.
+    #[test]
+    fn every_state_draws_at_any_size() {
+        let ctx = egui::Context::default();
+        let lines = buffer(30);
+        let empty = VecDeque::new();
+        for state in [
+            Liveness::Live,
+            Liveness::Done,
+            Liveness::Attention(Attn::PermWait),
+            Liveness::Attention(Attn::Stuck),
+        ] {
+            for (w, h) in [(600.0, 400.0), (120.0, 40.0), (1.0, 1.0)] {
+                let mut view = PaneView {
+                    dirty: true,
+                    follow: Follow {
+                        following: false,
+                        unseen: 12,
+                    },
+                    ..PaneView::default()
+                };
+                let mut out = ctx.run_ui(egui::RawInput::default(), |ui| {
+                    ui.set_max_size(Vec2::new(w, h));
+                    let pane = Pane {
+                        state,
+                        selected: true,
+                        pinned: true,
+                        attn_elapsed: Some(9.0),
+                        ..pane(if w > 100.0 { &lines } else { &empty })
+                    };
+                    render(ui, &pane, &mut view);
+                });
+                out.textures_delta.clear();
+            }
+        }
+    }
+
+    #[test]
+    fn the_border_takes_the_session_state_unless_the_pane_is_selected() {
+        let empty = VecDeque::new();
+        let base = pane(&empty);
+        assert_eq!(
+            border_color(&Pane {
+                selected: true,
+                state: Liveness::Done,
+                ..base
+            }),
+            palette::color(Sem::Stat)
+        );
+        assert_eq!(border_color(&base), palette::BORDER);
+        assert_eq!(
+            border_color(&Pane {
+                state: Liveness::Attention(Attn::Stuck),
+                ..base
+            }),
+            palette::color(Sem::Error)
+        );
+        assert_eq!(
+            border_color(&Pane {
+                state: Liveness::Done,
+                ..base
+            }),
+            palette::color(Sem::Dim)
+        );
+        assert_eq!(
+            border_color(&Pane {
+                state: Liveness::Done,
+                pinned: true,
+                ..base
+            }),
+            palette::color(Sem::User)
+        );
+    }
+
+    /// Colors come from the shared [`Sem`] table, so a pane and the TUI paint
+    /// the same event the same way.
+    #[test]
+    fn a_layout_job_carries_each_segments_semantic_color() {
+        let line = StyledLine(vec![
+            Seg::new(Sem::Tool, "Bash"),
+            Seg::new(Sem::Dim, " ls -la"),
+        ]);
+        let job = job(&line, &FontId::monospace(12.0));
+        assert_eq!(job.sections.len(), 2);
+        assert_eq!(job.sections[0].format.color, palette::color(Sem::Tool));
+        assert_eq!(job.sections[1].format.color, palette::color(Sem::Dim));
+        assert_eq!(job.text, "Bash ls -la");
+    }
+}

--- a/src/gui/roster.rs
+++ b/src/gui/roster.rs
@@ -92,11 +92,13 @@ pub fn render(ui: &mut Ui, app: &mut App) {
     render_status_strip(ui, app);
 }
 
-/// The attention-first toggle — the desktop-native stand-in for the TUI's
-/// `[a]` key. #77 adds the filter box and pin controls next to it.
+/// The attention-first and grid toggles — the desktop-native stand-ins for
+/// the TUI's `[a]` and `[l]` keys. #77 adds the filter box and pin controls
+/// next to them.
 fn render_top_bar(ui: &mut Ui, app: &mut App) {
     ui.horizontal(|ui| {
         ui.toggle_value(&mut app.view.attention_first, "⚠ attention first");
+        ui.toggle_value(&mut app.grid, "▦ grid");
     });
 }
 
@@ -233,7 +235,8 @@ mod tests {
     fn render_lays_out_every_branch() {
         let ctx = egui::Context::default();
         let (_tx, rx) = mpsc::channel();
-        let mut app = App::new(rx, vec!["/tmp/claude".to_string()]);
+        let (cmds, _cmd_rx) = mpsc::channel();
+        let mut app = App::new(rx, cmds, vec!["/tmp/claude".to_string()], 6);
         pass(&ctx, |ui| render(ui, &mut app));
 
         app.apply_event(Event::Roster(vec![

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -43,10 +43,6 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const REDRAW_INTERVAL: Duration = Duration::from_millis(100);
 /// Preview box: four lines of session detail plus its border.
 const PREVIEW_HEIGHT: u16 = 6;
-/// Transcript lines kept for an open pane. Far more than the preview box
-/// shows — the surplus is what grid mode's scrollback reads.
-const PANE_SCROLLBACK: usize = 5_000;
-
 /// Most panes the grid tiles at once, per the artboards: past this the last
 /// tile becomes the `+ N more sessions` placeholder and `[Tab]` pages.
 const GRID_SLOTS: usize = 6;
@@ -302,7 +298,7 @@ impl App {
     }
 
     /// Appends a fast tick's lines to a pane's buffer, dropping the oldest
-    /// past [`PANE_SCROLLBACK`]. Lines for any other key are stale — in
+    /// past [`pane::SCROLLBACK`]. Lines for any other key are stale — in
     /// flight when the pane closed — and discarded.
     fn buffer_pane(&mut self, key: &str, lines: Vec<StyledLine>) {
         if !self.open_panes.iter().any(|open| open == key) {
@@ -310,7 +306,7 @@ impl App {
         }
         let buffer = self.panes.entry(key.to_string()).or_default();
         buffer.extend(lines);
-        while buffer.len() > PANE_SCROLLBACK {
+        while buffer.len() > pane::SCROLLBACK {
             buffer.pop_front();
         }
     }
@@ -990,7 +986,7 @@ mod tests {
         }
 
         let buffer = &app.panes["a"];
-        assert_eq!(buffer.len(), PANE_SCROLLBACK);
+        assert_eq!(buffer.len(), pane::SCROLLBACK);
         assert_eq!(buffer.front().unwrap().to_plain(), "line 1000");
         assert_eq!(buffer.back().unwrap().to_plain(), "line 5999");
     }

--- a/src/ui/pane.rs
+++ b/src/ui/pane.rs
@@ -22,6 +22,12 @@ use crate::render::{Seg, Sem, StyledLine, fmt_elapsed};
 use crate::source::{Attn, Liveness};
 use crate::ui::palette;
 
+/// Transcript lines kept for an open pane. Far more than any viewport shows —
+/// the surplus is what grid mode's scrollback (and the desktop pane's) reads.
+/// One constant for both front ends: a chatty agent must not outgrow memory
+/// in either.
+pub const SCROLLBACK: usize = 5_000;
+
 /// A session's pane: what to draw and how far back it is scrolled.
 pub struct Pane<'a> {
     pub key: &'a str,
@@ -71,8 +77,9 @@ pub fn render(frame: &mut Frame, area: Rect, pane: &Pane) {
 
 /// The line appended below an attention pane's transcript, narrating why it
 /// needs eyes on it and for how long — `None` for `Live`/`Done`, which get
-/// no extra line.
-fn attention_status(state: Liveness, elapsed: Option<f64>) -> Option<StyledLine> {
+/// no extra line. Shared with [`crate::gui::pane`], so both front ends say
+/// the same thing about a session that needs eyes on it.
+pub(crate) fn attention_status(state: Liveness, elapsed: Option<f64>) -> Option<StyledLine> {
     let elapsed = fmt_elapsed(elapsed);
     match state {
         Liveness::Attention(Attn::PermWait) => Some(StyledLine(vec![Seg::new(
@@ -139,10 +146,19 @@ fn render_more(frame: &mut Frame, inner: Rect, below: usize) {
     );
 }
 
-/// Logical lines laid out for a pane `width` columns wide. Breaks at the
-/// last space that fits and hard-splits words longer than the pane; an empty
-/// logical line stays one empty display line.
+/// Logical lines laid out for a pane `width` columns wide, as ratatui lines.
 pub fn wrap(lines: &VecDeque<StyledLine>, width: usize) -> Vec<Line<'static>> {
+    wrap_styled(lines, width).iter().map(to_line).collect()
+}
+
+/// Logical lines broken into display lines `width` columns wide. Breaks at
+/// the last space that fits and hard-splits words longer than the pane; an
+/// empty logical line stays one empty display line.
+///
+/// Styling survives untouched, so the desktop pane wraps through this too
+/// ([`crate::gui::pane`]) and both front ends break the same transcript in
+/// the same places.
+pub fn wrap_styled(lines: &VecDeque<StyledLine>, width: usize) -> Vec<StyledLine> {
     if width == 0 {
         return Vec::new();
     }
@@ -152,21 +168,21 @@ pub fn wrap(lines: &VecDeque<StyledLine>, width: usize) -> Vec<Line<'static>> {
         .collect()
 }
 
-fn wrap_one(line: &StyledLine, width: usize) -> Vec<Line<'static>> {
+fn wrap_one(line: &StyledLine, width: usize) -> Vec<StyledLine> {
     let chars: Vec<(Sem, char)> = line
         .0
         .iter()
         .flat_map(|seg| seg.text.chars().map(move |c| (seg.sem, c)))
         .collect();
     if chars.is_empty() {
-        return vec![Line::default()];
+        return vec![StyledLine::default()];
     }
 
     let mut out = Vec::new();
     let mut start = 0;
     while start < chars.len() {
         if chars.len() - start <= width {
-            out.push(to_line(&chars[start..]));
+            out.push(to_styled(&chars[start..]));
             break;
         }
         // One past the last character that fits, so a line ending exactly on
@@ -177,30 +193,32 @@ fn wrap_one(line: &StyledLine, width: usize) -> Vec<Line<'static>> {
             Some(i) if i > 0 => (start + i, start + i + 1),
             _ => (hard, hard),
         };
-        out.push(to_line(&chars[start..end]));
+        out.push(to_styled(&chars[start..end]));
         start = next;
     }
     out
 }
 
-/// Runs of same-styled characters back into spans.
-fn to_line(chars: &[(Sem, char)]) -> Line<'static> {
-    let mut spans: Vec<Span> = Vec::new();
-    let mut current: Option<(Sem, String)> = None;
+/// Runs of same-styled characters back into segments.
+fn to_styled(chars: &[(Sem, char)]) -> StyledLine {
+    let mut segs: Vec<Seg> = Vec::new();
     for &(sem, c) in chars {
-        match &mut current {
-            Some((run, text)) if *run == sem => text.push(c),
-            _ => {
-                if let Some((run, text)) = current.replace((sem, c.to_string())) {
-                    spans.push(Span::styled(text, palette::style(run)));
-                }
-            }
+        match segs.last_mut() {
+            Some(seg) if seg.sem == sem => seg.text.push(c),
+            _ => segs.push(Seg::new(sem, c.to_string())),
         }
     }
-    if let Some((run, text)) = current {
-        spans.push(Span::styled(text, palette::style(run)));
-    }
-    Line::from(spans)
+    StyledLine(segs)
+}
+
+/// A display line as a ratatui line, one span per segment.
+fn to_line(line: &StyledLine) -> Line<'static> {
+    Line::from(
+        line.0
+            .iter()
+            .map(|seg| Span::styled(seg.text.clone(), palette::style(seg.sem)))
+            .collect::<Vec<Span>>(),
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
########## ISSUE #76 ##########
Desktop session panes: LayoutJob rendering, follow-scroll, zoom
Blocked by #74, #75.
MODEL: opus5 — the trickiest egui work in M9: styled-text LayoutJobs, follow-scroll state machine vs stick_to_bottom semantics, grid/zoom lifecycle tied to engine OpenPane/ClosePane — dense interacting state.

**In plain terms:** Live session panes in the desktop window — the streaming event feed with colors, auto-follow scrolling, and zoom.

---

**Why**
The heart of the monitor. `StyledLine` buffers already stream from the engine (#74's plumbing); this renders them natively. The trickiest egui work in M9: styled text runs and scroll mechanics.

**What to build**
Repo specifics: `StyledLine`/`Seg`/`Sem` are defined in render/mod.rs and produced by render/{claude,hermes,opencode}.rs — renderers stay untouched; you consume their output. Color via `Sem -> egui::Color32` in `src/gui/palette.rs`. Pane lifecycle: the engine already owns OpenPane/ClosePane (`UiCmd`) and the `--max-panes` eviction policy plus `Lifecycle { Started, Finished, Resumed, Evicted }` events — the desktop follows the same lifecycle as the TUI grid (ui/pane.rs is the reference implementation for follow/pause/badge/zoom semantics and the ~5000-line buffer cap). Selected-session id comes from #75's app state.
- `src/gui/pane.rs`: render a session's `StyledLine` buffer via `egui::text::LayoutJob` — one job per line, each `Seg` a styled section (color from the `Sem` mapping, monospace `FontId`). Wrapping is the layout job's, renderers stay untouched. VERIFY LayoutJob/FontId API against the egui version #74 pinned.
- Scrolling: `ScrollArea` with stick-to-bottom while following; any manual scroll pauses follow and shows a floating `▼ N new` badge; a "jump to latest" click (or `G`) resumes. Verify `stick_to_bottom`'s current semantics — if it fights manual scroll detection, track offset yourself.
- Layout: selected session's pane fills the area under the roster (list-mode analogue); a grid toggle tiles panes for all open sessions (reuse the engine's OpenPane/ClosePane commands and `--max-panes` policy). Double-click a pane (or `Enter`) zooms it; `Esc` back.
- Pane chrome: title `key — model`, border/heading tinted by state (attention amber/red, done ✓ dim), the inline attention status line rendering as the TUI does.
- Buffer cap shared with the TUI's (~5000 lines) — don't let a chatty agent grow memory unbounded; reuse/extract the cap constant rather than hardcoding a second copy.
Seam note: #77 adds `Enter`-zoom and `g/G` shortcuts through `ctx.input` and pin-holds-pane-slot semantics — keep the follow/zoom state per-pane in app state with a small, testable transition function (scroll-event → follow on/off, new-lines → badge count) rather than burying it in the draw closure.

**Out of scope**
Text selection/copy niceties beyond what egui gives free. Search-in-pane (future).

**Acceptance criteria**
- Screen recording in PR: two live sessions streaming side by side, colors matching the TUI for the same events; scroll up → follow pauses + badge; jump resumes; zoom in/out.
- A 5000-line buffer scrolls without visible jank (note frame time from egui's built-in stats).
- `cargo test` + CI green.