### PR TITLE
menubar: launch at login via launchctl + brew service block

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,29 @@ tmux involved — that was the mechanism of the original Python implementation
 this replaces; see
 [Predecessor](packaging/RELEASE_NOTES.md#7-predecessor-the-python-implementation).
 
+## Menu bar (macOS)
+
+`hermon menubar` puts a status item in the macOS menu bar, showing live fleet
+counts and attention state (⏸ waiting on permission, ⚠ stuck tools) with a
+live dropdown. Useful for monitoring without dedicating a whole window.
+
+**Notification behavior:** The menu bar is the default notifier. When `hermon
+watch` is running, it automatically defers to it (so you get one banner stream,
+not two); pass `--notify` to either to override. The `[m]` key mutes both.
+
+**Launch at login:**
+
+```bash
+# Install: register with launchd so the menu bar starts when you log in
+hermon menubar --install-login-item
+
+# Uninstall: stop launching at login
+hermon menubar --uninstall-login-item
+```
+
+With launch-at-login installed, the menu bar stays running across reboots and
+automatically restarts if it crashes. Logs go to `~/.local/share/hermon/`.
+
 ## Views and keybindings
 
 `hermon watch` has two view modes, `l` toggles between them:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,12 +21,13 @@ Full detail (issues, acceptance criteria) lives on the
 | [M5 — fleet controls](https://github.com/DrazThan/hermon/milestone/5) | ✅ done | Sort, filter, pin, paging, attention-sort, palette overlay. |
 | [M6 — notifications](https://github.com/DrazThan/hermon/milestone/6) | ✅ done | `decide_alerts`/`AlertHistory` pure core ([#43](https://github.com/DrazThan/hermon/issues/43)); delivery (`osascript`), mute key and CLI flags ([#44](https://github.com/DrazThan/hermon/issues/44)). |
 | [M7 — polish & packaging](https://github.com/DrazThan/hermon/milestone/7) | ✅ done | README + this roadmap ([#45](https://github.com/DrazThan/hermon/issues/45)), release build + brew tap ([#46](https://github.com/DrazThan/hermon/issues/46)), retiring `hermon.py` ([#47](https://github.com/DrazThan/hermon/issues/47)). |
+| [M8 — menu bar launch-at-login](https://github.com/DrazThan/hermon/milestone/8) | ✅ done | `--install-login-item` / `--uninstall-login-item` flags on `hermon menubar` to register with launchd ([#73](https://github.com/DrazThan/hermon/issues/73)); formula update, README docs. |
 
 ## Sequencing notes
 
-- Every milestone is closed. M7 finished with #47, which deleted `hermon.py`
-  and its `unittest` suite after a final row-for-row parity signoff of
-  `hermon ls` and `hermon render` against them on all three sources.
+- Every milestone is closed. M8 brings launch-at-login support to the menu bar
+  via `--install-login-item` / `--uninstall-login-item`, shipping with a formula
+  update in the tap and README documentation.
 - The Rust binary is now the only implementation. The Python one is reachable
   at the `python-final` tag — see
   [Predecessor](../packaging/RELEASE_NOTES.md#7-predecessor-the-python-implementation).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,23 @@ pub enum Command {
     /// Stream one session's transcript to stdout until Ctrl-C.
     Render(RenderArgs),
     /// Live fleet counts in the macOS menu bar (macOS only).
-    Menubar(SourceArgs),
+    Menubar(MenubarArgs),
+}
+
+/// Menubar-specific options, including source flags and login-item management.
+#[derive(Debug, Args)]
+pub struct MenubarArgs {
+    #[command(flatten)]
+    pub source: SourceArgs,
+
+    /// Write a LaunchAgent plist to ~/.config/hermon/LaunchAgents/dev.hermon.menubar.plist
+    /// and register it with launchctl so `hermon menubar` starts at login.
+    #[arg(long)]
+    pub install_login_item: bool,
+
+    /// Unregister and delete the LaunchAgent plist, removing launch-at-login.
+    #[arg(long)]
+    pub uninstall_login_item: bool,
 }
 
 /// `hermon render C:0f865f`: one session's pane body on stdout, the parity

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod cli;
 pub mod config;
 pub mod engine;
 pub mod gui;
+#[cfg(target_os = "macos")]
+pub mod login_item;
 pub mod menubar;
 pub mod notify;
 pub mod render;
@@ -106,23 +108,44 @@ pub fn run() -> anyhow::Result<()> {
         }
         Command::Render(args) => render(&args),
         Command::Menubar(args) => {
+            if args.install_login_item {
+                #[cfg(target_os = "macos")]
+                {
+                    return login_item::install();
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    anyhow::bail!("--install-login-item: macOS only");
+                }
+            }
+            if args.uninstall_login_item {
+                #[cfg(target_os = "macos")]
+                {
+                    return login_item::uninstall();
+                }
+                #[cfg(not(target_os = "macos"))]
+                {
+                    anyhow::bail!("--uninstall-login-item: macOS only");
+                }
+            }
+
             // Same fresh window as `watch` (`hermon.py:1463`); menubar is
             // the same live-fleet view, just in the status bar. Nothing
             // outranks it, so this only ever honours an explicit flag — but
             // it goes through the same seam so #77's `gui` slots in as one
             // more arm.
-            let notify = arbitrated_notify_cfg(&args, UiKind::Menubar);
-            let replay = replay_from(&args);
+            let notify = arbitrated_notify_cfg(&args.source, UiKind::Menubar);
+            let replay = replay_from(&args.source);
             let config = EngineConfig {
-                claude_dir: args.claude_dir,
-                hermes_db: args.hermes_db,
-                opencode_db: args.opencode_db,
-                hermes_log: args.hermes_log,
-                idle_timeout: args.idle_timeout,
+                claude_dir: args.source.claude_dir,
+                hermes_db: args.source.hermes_db,
+                opencode_db: args.source.opencode_db,
+                hermes_log: args.source.hermes_log,
+                idle_timeout: args.source.idle_timeout,
                 fresh_window: 300.0,
-                interval: Duration::from_secs_f64(args.interval),
-                linger: args.linger,
-                max_panes: args.max_panes,
+                interval: Duration::from_secs_f64(args.source.interval),
+                linger: args.source.linger,
+                max_panes: args.source.max_panes,
                 notify,
                 replay,
             };

--- a/src/login_item.rs
+++ b/src/login_item.rs
@@ -1,0 +1,132 @@
+//! Launch-at-login integration for `hermon menubar` on macOS via LaunchAgent.
+//!
+//! This module provides `--install-login-item` and `--uninstall-login-item` to
+//! write/remove a LaunchAgent plist and register it with launchctl.
+
+use anyhow::{Result, bail};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+const PLIST_ID: &str = "dev.hermon.menubar";
+const PLIST_FILENAME: &str = "dev.hermon.menubar.plist";
+
+/// Path where the LaunchAgent plist is stored.
+fn plist_path() -> Result<PathBuf> {
+    let config_dir =
+        dirs::config_dir().ok_or_else(|| anyhow::anyhow!("cannot determine config directory"))?;
+    let launch_agents = config_dir.join("hermon").join("LaunchAgents");
+    Ok(launch_agents.join(PLIST_FILENAME))
+}
+
+/// Path to the hermon binary.
+fn hermon_binary_path() -> Result<String> {
+    let exe = std::env::current_exe()?;
+    Ok(exe.to_string_lossy().to_string())
+}
+
+/// Generate the LaunchAgent plist content as a string.
+fn plist_content(hermon_path: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>{}</string>
+	<key>Program</key>
+	<string>{}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>{}</string>
+		<string>menubar</string>
+	</array>
+	<key>KeepAlive</key>
+	<true/>
+	<key>LimitLoadToSessionType</key>
+	<string>Aqua</string>
+	<key>StandardOutPath</key>
+	<string>$HOME/.local/share/hermon/menubar.log</string>
+	<key>StandardErrorPath</key>
+	<string>$HOME/.local/share/hermon/menubar-error.log</string>
+</dict>
+</plist>
+"#,
+        PLIST_ID, hermon_path, hermon_path
+    )
+}
+
+/// Install the LaunchAgent and register it with launchctl.
+pub fn install() -> Result<()> {
+    let plist_path = plist_path()?;
+    let hermon_path = hermon_binary_path()?;
+
+    // Create directory if it doesn't exist
+    if let Some(parent) = plist_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    // Create log directory
+    if let Some(home) = dirs::home_dir() {
+        let log_dir = home.join(".local/share/hermon");
+        fs::create_dir_all(log_dir)?;
+    }
+
+    // Write the plist
+    let content = plist_content(&hermon_path);
+    fs::write(&plist_path, content)?;
+
+    // Unload the service first in case it's already loaded (idempotent)
+    let _ = Command::new("launchctl")
+        .arg("unload")
+        .arg(&plist_path)
+        .output();
+
+    // Load the service
+    let output = Command::new("launchctl")
+        .arg("load")
+        .arg(&plist_path)
+        .output()?;
+
+    if !output.status.success() {
+        bail!(
+            "launchctl load failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    println!("✓ Launch at login installed. hermon menubar will start when you log in.");
+    println!("  Plist: {}", plist_path.display());
+    println!("  To uninstall, run: hermon menubar --uninstall-login-item");
+
+    Ok(())
+}
+
+/// Uninstall the LaunchAgent and deregister it with launchctl.
+pub fn uninstall() -> Result<()> {
+    let plist_path = plist_path()?;
+
+    // Unload the service first
+    let output = Command::new("launchctl")
+        .arg("unload")
+        .arg(&plist_path)
+        .output()?;
+
+    if !output.status.success() {
+        // If it wasn't loaded, that's fine — proceed to delete the file
+        eprintln!(
+            "launchctl unload: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // Delete the plist
+    if plist_path.exists() {
+        fs::remove_file(&plist_path)?;
+    }
+
+    println!("✓ Launch at login uninstalled.");
+    println!("  Plist deleted: {}", plist_path.display());
+
+    Ok(())
+}


### PR DESCRIPTION
########## ISSUE #73 ##########
Launch at login via brew services; formula bump and docs
Blocked by #70, #71, #72 — ships their result.
MODEL: haiku4.5 — formula/plist/docs work with explicit verification steps spelled out; small and checklist-shaped.

**In plain terms:** Have the menu-bar app start when you log in, installable the same brew way, with docs.

---

**Why**
An always-visible monitor you must remember to start isn't always-visible. Brew already installs the binary; brew services can keep `hermon menubar` running.

**What to build**
Repo specifics: the tap is `drazthan/hermon` (formula in `DrazThan/homebrew-hermon`), live since v0.1.0 with a release runbook from #46 — follow it for the bump. If the launch-agent fallback path is taken, the flags land in cli.rs on the existing `Menubar` subcommand (add flags only; #74/#78 touch cli.rs too — keep the diff to your own subcommand).
- `service` block in the tap formula running `hermon menubar`, so `brew services start hermon` = launch at login via launchd. Verify: menu-bar apps under launchd need the Aqua session type (`LimitLoadToSessionType Aqua`) — check what brew's service DSL supports (`run_type :immediate`, `keep_alive`); if the DSL can't express it, ship a `hermon menubar --install-login-item` that writes `~/Library/LaunchAgents/dev.hermon.menubar.plist` instead (and `--uninstall-login-item`), and say so in the formula caveats.
- Bump formula for the release containing M8; release notes.
- README: menubar section — what it shows, notification arbitration behavior (from #72: menubar is the default notifier, `watch` auto-defers, `--notify` overrides), launch-at-login instructions, screenshot.
- `docs/roadmap.md`: M8 section added and closed out.

**Out of scope**
Signed .app bundle, Sparkle-style updates — future productization. (#78 handles the desktop .app cask separately — don't touch Casks/.)

**Acceptance criteria**
- Clean-shell transcript in the PR: `brew upgrade hermon` (or tap install), then `brew services start hermon` OR the login-item flag path — menu bar item appears after logout/login or service start.
- `brew audit --strict` passes (or deviations justified).
- README instructions verified by following them literally.