### PR TITLE
gui: fleet controls — filter, pin, shortcuts, mute, arbitration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,8 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
 dependencies = [
+ "enumn",
+ "serde",
  "uuid",
 ]
 
@@ -146,6 +148,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -1294,6 +1297,7 @@ checksum = "fc883f505d446814c0226bef4b64564b9adb9966fc00c88c57ce6d827dd152d6"
 dependencies = [
  "bytemuck",
  "emath",
+ "serde",
 ]
 
 [[package]]
@@ -1322,6 +1326,8 @@ dependencies = [
  "pollster",
  "profiling",
  "raw-window-handle",
+ "ron",
+ "serde",
  "static_assertions",
  "wasm-bindgen",
  "web-sys",
@@ -1346,6 +1352,8 @@ dependencies = [
  "log",
  "nohash-hasher",
  "profiling",
+ "ron",
+ "serde",
  "smallvec",
  "unicode-segmentation",
  "web-sys",
@@ -1387,6 +1395,7 @@ dependencies = [
  "objc2-ui-kit 0.3.2",
  "profiling",
  "raw-window-handle",
+ "serde",
  "smithay-clipboard",
  "web-time",
  "webbrowser",
@@ -1435,6 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce03cf1604f74515830012c29991beb0b58f69e4e43f5afe22fa7afed65ccd5"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -1485,6 +1495,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "epaint"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1523,7 @@ dependencies = [
  "parking_lot",
  "profiling",
  "self_cell",
+ "serde",
  "skrifa",
  "smallvec",
  "unicode-general-category",
@@ -1684,6 +1706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
 dependencies = [
  "bytemuck",
+ "serde",
 ]
 
 [[package]]
@@ -4280,6 +4303,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "ron"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81116b9531d61eabc41aeb228e4b6b2435bcca3233b98cf3b3077d4e6e9debb3"
+dependencies = [
+ "bitflags 2.13.1",
+ "once_cell",
+ "serde",
+ "serde_derive",
+ "typeid",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rsqlite-vfs"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4578,6 +4615,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smithay-client-toolkit"
@@ -5182,6 +5222,12 @@ checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
 dependencies = [
  "rustc-hash 2.1.3",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ chrono = "0.4.45"
 clap = { version = "4.6.6", features = ["derive"] }
 crossterm = "0.29.0"
 dirs = "6.0.0"
-eframe = "0.36.1"
+eframe = { version = "0.36.1", features = ["persistence"] }
 egui_extras = "0.36.1"
 ratatui = "0.30.2"
 regex = "1.13.1"

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -25,6 +25,7 @@ use std::thread;
 use anyhow::anyhow;
 use eframe::egui;
 
+use crate::arbitration::{self, PidGuard, UiKind};
 use crate::config::EngineConfig;
 use crate::engine::{Engine, Event, Lifecycle, UiCmd};
 use crate::render::StyledLine;
@@ -43,6 +44,15 @@ const PANE_AREA_MIN: f32 = 80.0;
 /// A pane whose session has produced no transcript yet.
 static NO_LINES: VecDeque<StyledLine> = VecDeque::new();
 
+/// The top bar's filter [`egui::TextEdit`]'s id, so `[/]` can request focus
+/// on it from [`App::handle_keys`] without the widget needing to reach back
+/// into the key handler itself.
+const FILTER_ID: &str = "hermon-filter";
+
+/// The key `eframe::Storage` persists [`App::grid`] (the desktop twin of the
+/// TUI's list/grid mode) under.
+const GRID_STORAGE_KEY: &str = "hermon-grid";
+
 /// Opens the window and blocks until it closes, then shuts the engine down
 /// and joins it.
 pub fn run_gui(config: EngineConfig) -> anyhow::Result<()> {
@@ -54,6 +64,11 @@ pub fn run_gui(config: EngineConfig) -> anyhow::Result<()> {
         config.opencode_db.clone(),
     ];
     let max_panes = config.max_panes;
+    // Claims the notifier pidfile so a `watch` started alongside this window
+    // sees `gui` running and yields to it (#72's arbitration, extended here
+    // the same way menubar already registers). Held for the window's whole
+    // lifetime and dropped — pidfile removed — once `run_native` returns.
+    let _pidfile = config.notify.any_enabled().then(claim_notifier).flatten();
     let (event_tx, event_rx) = mpsc::channel();
     let (cmd_tx, cmd_rx) = mpsc::channel();
     let engine = Engine::spawn(config, event_tx, cmd_rx);
@@ -73,12 +88,14 @@ pub fn run_gui(config: EngineConfig) -> anyhow::Result<()> {
         Box::new(move |cc| {
             palette::install(&cc.egui_ctx);
             let events = event_rx.take().expect("app creator runs once");
-            Ok(Box::new(App::new(
+            let mut app = App::new(
                 wake(events, cc.egui_ctx.clone()),
                 app_cmds,
                 paths,
                 max_panes,
-            )))
+            );
+            app.restore(cc.storage);
+            Ok(Box::new(app))
         }),
     );
 
@@ -87,6 +104,20 @@ pub fn run_gui(config: EngineConfig) -> anyhow::Result<()> {
     let _ = cmd_tx.send(UiCmd::Shutdown);
     let _ = engine.join();
     result.map_err(|err| anyhow!("gui: {err}"))
+}
+
+/// Claims the notifier pidfile for [`UiKind::Gui`], the same pattern the
+/// menubar backend uses for its own kind. Not fatal on failure: the window
+/// still notifies, a concurrent `watch` just won't know to stand down.
+fn claim_notifier() -> Option<PidGuard> {
+    let dir = arbitration::runtime_dir()?;
+    match arbitration::claim(&dir, UiKind::Gui) {
+        Ok(guard) => Some(guard),
+        Err(err) => {
+            eprintln!("hermon gui: could not claim the notifier pidfile: {err}");
+            None
+        }
+    }
 }
 
 /// Relays engine events onto a second channel, repainting for each one.
@@ -130,11 +161,26 @@ pub struct App {
     /// The active sort, filter and attention-first flag (#40's pure core),
     /// which #75's header clicks and #77's controls drive.
     pub view: ViewState,
+    /// The filter box's text as typed. Applied live through
+    /// [`ViewState::set_filter`] on every change — unlike the TUI's modal
+    /// palette there is no separate draft/commit step, since the box is
+    /// always on screen rather than something `[Enter]` dismisses.
+    pub filter_input: String,
+    /// The last filter parse error, if the current `filter_input` doesn't
+    /// parse. [`ViewState::set_filter`] leaves the previous filter active
+    /// when this is set, so a typo never blanks the roster.
+    pub filter_error: Option<String>,
+    /// Global notification mute, `[m]` toggles — the desktop twin of
+    /// [`crate::ui::App::muted`], mirroring the engine's own
+    /// [`AlertHistory`](crate::notify::AlertHistory) copy instantly rather
+    /// than waiting on a round trip through it.
+    pub muted: bool,
     /// The store paths the engine is watching, for the empty state —
     /// [`crate::ui::App::paths`]'s desktop twin.
     pub paths: Vec<String>,
     /// Whether the pane area tiles every session with a slot, rather than
-    /// just the selected one.
+    /// just the selected one. Persisted across launches via `eframe`'s
+    /// native storage.
     pub grid: bool,
     /// Whether the selected pane has the window to itself.
     pub zoomed: bool,
@@ -167,6 +213,9 @@ impl App {
             selected_id: None,
             panes: HashMap::new(),
             view: ViewState::default(),
+            filter_input: String::new(),
+            filter_error: None,
+            muted: false,
             paths,
             grid: false,
             zoomed: false,
@@ -183,6 +232,41 @@ impl App {
     /// opens with.
     pub fn default_title() -> String {
         title_for(0)
+    }
+
+    /// Restores window state persisted by [`App::save`] — currently just
+    /// [`App::grid`], the desktop twin of the TUI's list/grid mode. A no-op
+    /// on the very first launch, when `storage` has nothing under the key
+    /// yet.
+    fn restore(&mut self, storage: Option<&dyn eframe::Storage>) {
+        if let Some(storage) = storage {
+            self.grid = eframe::get_value(storage, GRID_STORAGE_KEY).unwrap_or(false);
+        }
+    }
+
+    /// Sets the engine's global mute flag `[m]` and the top bar toggle both
+    /// read.
+    fn toggle_muted(&mut self) {
+        self.muted = !self.muted;
+        let _ = self.cmds.send(UiCmd::SetMuted(self.muted));
+    }
+
+    /// Pins or unpins `id`, then tells the engine the whole pinned set so its
+    /// `--max-panes` eviction never picks one of them — the desktop twin of
+    /// [`crate::ui::App::toggle_pin`].
+    fn toggle_pin(&mut self, id: &str) {
+        if self.view.is_pinned(id) {
+            self.view.unpin(id);
+        } else {
+            self.view.pin(id);
+        }
+        let pinned_keys: std::collections::HashSet<String> = self
+            .roster
+            .iter()
+            .filter(|row| self.view.is_pinned(&row.id))
+            .map(|row| row.key.clone())
+            .collect();
+        let _ = self.cmds.send(UiCmd::Pinned(pinned_keys));
     }
 
     /// Applies everything that has arrived since the last frame. Returns the
@@ -310,19 +394,55 @@ impl App {
         self.selected_row().map(|row| row.key.clone())
     }
 
-    /// The keyboard half of the pane controls: zoom in and out, and park the
-    /// selected pane at the top of its scrollback or back on its tail. #77
-    /// owns the rest of the key map.
+    /// Where the selected session currently sits among the visible
+    /// (filtered, sorted) rows; 0 when it is gone, which is also where an
+    /// untouched cursor starts — the desktop twin of
+    /// [`crate::ui::App::selected_index`].
+    fn selected_index(&self) -> usize {
+        self.selected_id
+            .as_ref()
+            .and_then(|id| {
+                view::apply(&self.roster, &self.view)
+                    .rows
+                    .iter()
+                    .position(|row| &row.id == id)
+            })
+            .unwrap_or(0)
+    }
+
+    fn select_at(&mut self, position: usize) {
+        let rows = view::apply(&self.roster, &self.view).rows;
+        let position = position.min(rows.len().saturating_sub(1));
+        self.selected_id = rows.get(position).map(|row| row.id.clone());
+    }
+
+    fn select_next(&mut self) {
+        self.select_at(self.selected_index() + 1);
+    }
+
+    fn select_prev(&mut self) {
+        self.select_at(self.selected_index().saturating_sub(1));
+    }
+
+    /// The keyboard half of the fleet controls: `j`/`k` move the selection,
+    /// `Enter` zooms and `g`/`G` jump the selected pane's scrollback (#76),
+    /// `m` mutes and `/` focuses the filter box (#77). Skipped entirely
+    /// while a widget — the filter box included — already wants the
+    /// keyboard, so typing a filter term never doubles as a shortcut.
     fn handle_keys(&mut self, ctx: &egui::Context) {
         if ctx.egui_wants_keyboard_input() {
             return;
         }
-        let (escape, enter, top, tail) = ctx.input(|input| {
+        let (escape, enter, top, tail, next, prev, mute, focus_filter) = ctx.input(|input| {
             (
                 input.key_pressed(egui::Key::Escape),
                 input.key_pressed(egui::Key::Enter),
                 input.key_pressed(egui::Key::G) && !input.modifiers.shift,
                 input.key_pressed(egui::Key::G) && input.modifiers.shift,
+                input.key_pressed(egui::Key::J),
+                input.key_pressed(egui::Key::K),
+                input.key_pressed(egui::Key::M),
+                input.key_pressed(egui::Key::Slash),
             )
         });
         if escape {
@@ -330,6 +450,18 @@ impl App {
         }
         if enter && self.selected_row().is_some() {
             self.zoomed = true;
+        }
+        if next {
+            self.select_next();
+        }
+        if prev {
+            self.select_prev();
+        }
+        if mute {
+            self.toggle_muted();
+        }
+        if focus_filter {
+            ctx.memory_mut(|memory| memory.request_focus(egui::Id::new(FILTER_ID)));
         }
         if let Some(key) = self.selected_key().filter(|_| top || tail) {
             let view = self.pane_views.entry(key).or_default();
@@ -442,6 +574,13 @@ impl eframe::App for App {
     fn clear_color(&self, _visuals: &egui::Visuals) -> [f32; 4] {
         palette::BG.to_normalized_gamma_f32()
     }
+
+    /// Persists [`App::grid`]; window size and position are `eframe`'s own
+    /// `persist_window` doing the rest, automatic once the `persistence`
+    /// feature is on.
+    fn save(&mut self, storage: &mut dyn eframe::Storage) {
+        eframe::set_value(storage, GRID_STORAGE_KEY, &self.grid);
+    }
 }
 
 /// `hermon — 3 live`, the window title.
@@ -451,6 +590,7 @@ fn title_for(live: usize) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::sync::mpsc::Sender;
     use std::time::{Duration, Instant};
 
@@ -821,5 +961,184 @@ mod tests {
             rows.iter()
                 .any(|r| Some(r.id.as_str()) == app.selected_id.as_deref())
         );
+    }
+
+    // ------------------------------------------------------------ #77 controls
+
+    /// `j`/`k` walk the visible (filtered, sorted) rows and clamp at either
+    /// end rather than wrapping — the desktop twin of the TUI's own
+    /// `select_next`/`select_prev`.
+    #[test]
+    fn select_next_and_prev_move_through_the_visible_rows_and_clamp() {
+        let (_tx, mut app) = app();
+        app.apply_event(Event::Roster(vec![
+            row("C:aaa", Liveness::Live),
+            row("H:bbb", Liveness::Live),
+        ]));
+        app.selected_id = Some("C:aaa-id".to_string());
+
+        app.select_next();
+        assert_eq!(app.selected_id.as_deref(), Some("H:bbb-id"));
+        app.select_next();
+        assert_eq!(
+            app.selected_id.as_deref(),
+            Some("H:bbb-id"),
+            "clamps at the last row rather than wrapping"
+        );
+
+        app.select_prev();
+        assert_eq!(app.selected_id.as_deref(), Some("C:aaa-id"));
+        app.select_prev();
+        assert_eq!(
+            app.selected_id.as_deref(),
+            Some("C:aaa-id"),
+            "clamps at the first row rather than wrapping"
+        );
+    }
+
+    /// Pinning tells the engine the whole pinned set, keyed by
+    /// [`RosterRow::key`] — the desktop twin of `crate::ui::App::toggle_pin`,
+    /// which #77's pin column and `[p]`-equivalent both call.
+    #[test]
+    fn toggle_pin_flips_view_state_and_sends_the_whole_pinned_set() {
+        let (tx, cmds, mut app) = app_with_cmds();
+        tx.send(Event::Roster(vec![
+            row("C:aaa", Liveness::Live),
+            row("H:bbb", Liveness::Live),
+        ]))
+        .unwrap();
+        app.drain();
+
+        app.toggle_pin("C:aaa-id");
+        assert!(app.view.is_pinned("C:aaa-id"));
+        assert_eq!(
+            cmds.try_iter().collect::<Vec<_>>(),
+            vec![UiCmd::Pinned(HashSet::from(["C:aaa".to_string()]))]
+        );
+
+        app.toggle_pin("C:aaa-id");
+        assert!(!app.view.is_pinned("C:aaa-id"));
+        assert_eq!(
+            cmds.try_iter().collect::<Vec<_>>(),
+            vec![UiCmd::Pinned(HashSet::new())]
+        );
+    }
+
+    /// `[m]` and the mute button both go through this: it flips the local
+    /// copy instantly, the same way `crate::ui::App::muted` does, and tells
+    /// the engine's `AlertHistory`.
+    #[test]
+    fn toggle_muted_flips_the_flag_and_notifies_the_engine() {
+        let (_tx, cmds, mut app) = app_with_cmds();
+        app.toggle_muted();
+        assert!(app.muted);
+        assert_eq!(
+            cmds.try_iter().collect::<Vec<_>>(),
+            vec![UiCmd::SetMuted(true)]
+        );
+
+        app.toggle_muted();
+        assert!(!app.muted);
+        assert_eq!(
+            cmds.try_iter().collect::<Vec<_>>(),
+            vec![UiCmd::SetMuted(false)]
+        );
+    }
+
+    /// `j`/`k` move the selection and `m` mutes, through the same
+    /// `ctx.input` path #76's `Enter`/`Esc`/`g`/`G` already use — extending
+    /// it, not replacing it.
+    #[test]
+    fn j_k_and_m_drive_selection_and_mute_through_handle_keys() {
+        let (_tx, mut app) = app();
+        let ctx = egui::Context::default();
+        app.apply_event(Event::Roster(vec![
+            row("C:aaa", Liveness::Live),
+            row("H:bbb", Liveness::Live),
+        ]));
+        app.selected_id = Some("C:aaa-id".to_string());
+
+        let key = |key: egui::Key| egui::RawInput {
+            events: vec![egui::Event::Key {
+                key,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::default(),
+            }],
+            ..egui::RawInput::default()
+        };
+
+        let mut out = ctx.run_ui(key(egui::Key::J), |ui| app.draw(ui));
+        out.textures_delta.clear();
+        assert_eq!(app.selected_id.as_deref(), Some("H:bbb-id"));
+
+        let mut out = ctx.run_ui(key(egui::Key::K), |ui| app.draw(ui));
+        out.textures_delta.clear();
+        assert_eq!(app.selected_id.as_deref(), Some("C:aaa-id"));
+
+        let mut out = ctx.run_ui(key(egui::Key::M), |ui| app.draw(ui));
+        out.textures_delta.clear();
+        assert!(app.muted);
+    }
+
+    /// `[/]` moves keyboard focus to the filter box so typing goes straight
+    /// into it, without the box needing to reach back into the key handler.
+    #[test]
+    fn slash_requests_focus_on_the_filter_box() {
+        let (_tx, mut app) = app();
+        let ctx = egui::Context::default();
+
+        let key = egui::RawInput {
+            events: vec![egui::Event::Key {
+                key: egui::Key::Slash,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: egui::Modifiers::default(),
+            }],
+            ..egui::RawInput::default()
+        };
+        let mut out = ctx.run_ui(key, |ui| app.draw(ui));
+        out.textures_delta.clear();
+
+        let id = egui::Id::new(FILTER_ID);
+        assert_eq!(ctx.memory(|memory| memory.focused()), Some(id));
+    }
+
+    /// A fake in-memory `Storage` — `eframe`'s own file-backed one only
+    /// exists once a window has actually opened, so the save/restore round
+    /// trip is tested against this instead.
+    #[derive(Default)]
+    struct FakeStorage(HashMap<String, String>);
+
+    impl eframe::Storage for FakeStorage {
+        fn get_string(&self, key: &str) -> Option<String> {
+            self.0.get(key).cloned()
+        }
+        fn set_string(&mut self, key: &str, value: String) {
+            self.0.insert(key.to_string(), value);
+        }
+        fn remove_string(&mut self, key: &str) {
+            self.0.remove(key);
+        }
+        fn flush(&mut self) {}
+    }
+
+    /// [`App::save`] and [`App::restore`] round-trip the grid flag — the
+    /// "view mode" half of #77's window-state persistence (size and position
+    /// are `eframe`'s own `persist_window`, not this app's storage key).
+    #[test]
+    fn grid_mode_round_trips_through_storage() {
+        let make = app;
+        let (_tx, mut app) = make();
+        app.grid = true;
+        let mut storage = FakeStorage::default();
+        eframe::App::save(&mut app, &mut storage as &mut dyn eframe::Storage);
+
+        let (_tx2, mut restored) = make();
+        assert!(!restored.grid);
+        restored.restore(Some(&storage as &dyn eframe::Storage));
+        assert!(restored.grid);
     }
 }

--- a/src/gui/roster.rs
+++ b/src/gui/roster.rs
@@ -10,8 +10,9 @@
 use eframe::egui::{self, Color32, RichText, Ui};
 use egui_extras::{Column, TableBuilder, TableRow};
 
-use crate::render::{StyledLine, fmt_elapsed};
+use crate::render::{Sem, StyledLine, fmt_elapsed};
 use crate::roster::{RosterRow, commas, fmt_cost, tool_annotation, totals_line};
+use crate::ui::palette::pin_glyph;
 use crate::ui::roster::{empty_state, no_matches_state, row_sems};
 use crate::view::{self, SortKey, ViewState};
 
@@ -44,6 +45,7 @@ pub fn render(ui: &mut Ui, app: &mut App) {
     let selected_id = app.selected_id.clone();
     let mut sort_click: Option<SortKey> = None;
     let mut select_click: Option<String> = None;
+    let mut pin_click: Option<String> = None;
 
     egui::ScrollArea::vertical()
         .id_salt("roster-table")
@@ -52,6 +54,7 @@ pub fn render(ui: &mut Ui, app: &mut App) {
                 .striped(true)
                 .sense(egui::Sense::click())
                 .column(Column::exact(24.0))
+                .column(Column::exact(22.0))
                 .column(Column::initial(90.0).at_least(70.0))
                 .column(Column::initial(130.0).at_least(90.0))
                 .column(Column::remainder().at_least(100.0))
@@ -59,6 +62,7 @@ pub fn render(ui: &mut Ui, app: &mut App) {
                 .column(Column::initial(80.0).at_least(60.0))
                 .column(Column::initial(80.0).at_least(60.0))
                 .header(HEADER_HEIGHT, |mut header| {
+                    header.col(|_| {});
                     header.col(|_| {});
                     header.col(|ui| {
                         ui.label(RichText::new("key").color(palette::DIM));
@@ -72,8 +76,9 @@ pub fn render(ui: &mut Ui, app: &mut App) {
                 .body(|body| {
                     body.rows(ROW_HEIGHT, rows.len(), |mut row| {
                         let r = rows[row.index()];
+                        let pinned = app.view.is_pinned(&r.id);
                         row.set_selected(selected_id.as_deref() == Some(r.id.as_str()));
-                        row_cells(&mut row, r);
+                        row_cells(&mut row, r, pinned, &mut pin_click);
                         if row.response().clicked() {
                             select_click = Some(r.id.clone());
                         }
@@ -87,19 +92,72 @@ pub fn render(ui: &mut Ui, app: &mut App) {
     if let Some(id) = select_click {
         app.selected_id = Some(id);
     }
+    if let Some(id) = pin_click {
+        app.toggle_pin(&id);
+    }
 
     ui.separator();
     render_status_strip(ui, app);
 }
 
-/// The attention-first and grid toggles — the desktop-native stand-ins for
-/// the TUI's `[a]` and `[l]` keys. #77 adds the filter box and pin controls
-/// next to them.
+/// The attention-first and grid toggles, the mute button, and the filter
+/// box — the desktop-native stand-ins for the TUI's `[a]`, `[l]`, `[m]` and
+/// `[f]`/`[/]`. Filtering is live: every keystroke goes straight through
+/// [`ViewState::set_filter`], which keeps the previous filter active on a
+/// parse error rather than blanking the roster, so a typo just shows the red
+/// feedback without losing what was there. Active terms show as removable
+/// chips on their own row underneath.
 fn render_top_bar(ui: &mut Ui, app: &mut App) {
     ui.horizontal(|ui| {
         ui.toggle_value(&mut app.view.attention_first, "⚠ attention first");
         ui.toggle_value(&mut app.grid, "▦ grid");
+
+        let mute_label = if app.muted { "🔇 muted" } else { "🔔 mute" };
+        if ui.selectable_label(app.muted, mute_label).clicked() {
+            app.toggle_muted();
+        }
+
+        ui.separator();
+
+        let has_error = app.filter_error.is_some();
+        let mut edit = egui::TextEdit::singleline(&mut app.filter_input)
+            .id(egui::Id::new(super::FILTER_ID))
+            .hint_text("model=claude* cost>1.00");
+        if has_error {
+            edit = edit.text_color(palette::color(Sem::Error));
+        }
+        let response = ui.add(edit);
+        if response.changed() {
+            app.filter_error = app.view.set_filter(&app.filter_input).err();
+        }
+        if let Some(error) = &app.filter_error {
+            response.on_hover_text(error);
+        }
+
+        let output = view::apply(&app.roster, &app.view);
+        ui.label(
+            RichText::new(format!("{} of {}", output.matched, output.total)).color(palette::DIM),
+        );
     });
+
+    if !app.view.filter.chips().is_empty() {
+        ui.horizontal(|ui| {
+            let mut remove: Option<usize> = None;
+            for (i, chip) in app.view.filter.chips().iter().enumerate() {
+                if ui.small_button(format!("{chip} ✕")).clicked() {
+                    remove = Some(i);
+                }
+            }
+            if let Some(i) = remove {
+                let mut terms: Vec<&str> =
+                    app.view.filter.chips().iter().map(String::as_str).collect();
+                terms.remove(i);
+                let input = terms.join(" ");
+                app.filter_error = app.view.set_filter(&input).err();
+                app.filter_input = input;
+            }
+        });
+    }
 }
 
 /// One sortable header cell: the column label plus the active sort's arrow,
@@ -125,13 +183,33 @@ fn sort_header(
     });
 }
 
-/// One row's seven cells, colored by the row's attention state through the
-/// same [`row_sems`] mapping the TUI paints with.
-fn row_cells(row: &mut TableRow<'_, '_>, r: &RosterRow) {
+/// One row's eight cells (state glyph, pin toggle, then the six data
+/// columns), colored by the row's attention state through the same
+/// [`row_sems`] mapping the TUI paints with.
+fn row_cells(
+    row: &mut TableRow<'_, '_>,
+    r: &RosterRow,
+    pinned: bool,
+    pin_click: &mut Option<String>,
+) {
     let sems = row_sems(r.state);
     let (glyph, glyph_color) = palette::glyph_for_liveness(r.state);
     row.col(|ui| {
         ui.label(mono(glyph, glyph_color));
+    });
+    row.col(|ui| {
+        let color = if pinned {
+            palette::color(Sem::User)
+        } else {
+            palette::DIM
+        };
+        let clicked = ui
+            .add(egui::Button::new(RichText::new(pin_glyph()).color(color)).frame(false))
+            .on_hover_text(if pinned { "unpin" } else { "pin" })
+            .clicked();
+        if clicked {
+            *pin_click = Some(r.id.clone());
+        }
     });
     row.col(|ui| {
         ui.label(mono(&r.key, palette::color(sems.text)));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,10 @@ pub fn run() -> anyhow::Result<()> {
         }
         // The window is a second engine consumer, not a second engine
         // configuration: same flags and same 300s fresh window as `watch`.
+        // Arbitrated the same way `watch` is (#72/#77): a running menubar
+        // outranks it, so a `gui` alongside one silences its own banners.
         Command::Gui(args) => {
-            let notify = args.notify_cfg();
+            let notify = arbitrated_notify_cfg(&args, UiKind::Gui);
             let replay = replay_from(&args);
             let config = EngineConfig {
                 claude_dir: args.claude_dir,


### PR DESCRIPTION
########## ISSUE #77 ##########
Desktop fleet controls: filter, pin, shortcuts, arbitration
Blocked by #75, #76, and #72 (notifier arbitration mechanism).
MODEL: sonnet5 — feature-parity assembly over existing view.rs logic and #72's arbitration seam; broad but each piece is well-specified.

**In plain terms:** Round out the desktop app to feature parity: filter box, pinning, keyboard shortcuts, mute — everything the TUI can do.

---

**Why**
view.rs holds all the logic; this is its desktop cockpit, replacing the TUI's modal palette with always-visible native controls.

**What to build**
Repo specifics: everything mounts on the M9 chain's app state (`src/gui/mod.rs`, top bar from #75, pane state from #76). `ViewState { sort_key, filter language, pinned: HashSet keyed by RosterRow::id, attention_first }` and the filter parser live in view.rs — pure, unit-tested; call it, never reimplement. Mute is `AlertHistory::set_muted/is_muted` from notify.rs (same as the TUI's `[m]`). Arbitration is #72's pidfile-liveness module — it was built parameterized by UI kind for exactly this extension.
- Top bar filter `TextEdit` using the existing view.rs filter language (`model=claude*`, `cost>1.00`), live match count beside it, invalid-term feedback inline (red underline/tooltip, never a panic); active terms as removable chips.
- Pin: pin icon per row (📌/`*` fallback via the palette ASCII-fallback mechanism) toggling the `ViewState` pinned set; pinned semantics identical to the TUI (hold pane slots, page-1 priority).
- Keyboard parity where it makes sense: `j/k` selection, `Enter` zoom, `g/G`, `m` mute, `/` focuses the filter box — via `ctx.input` (VERIFY the key API against the egui version #74 pinned).
- Mute button + banner arbitration: the gui process registers as a notifier the same way `watch` does against a running menubar (#72's pidfile check, extended so any TWO hermon UIs never double-notify; precedence: menubar > gui > watch). Extend the arbitration module additively — don't change #72's watch/menubar behavior.
- Window state persistence (size/position/view mode) via eframe's native storage (verify the `persistence` feature flag / `Storage` API for the pinned eframe version).

**Out of scope**
New view logic — anything not already in view.rs is out.

**Acceptance criteria**
- Filter/pin behavior matches the TUI on the same fleet (side-by-side screenshots).
- Arbitration live check: gui + watch running → one banner per event.
- Keyboard walkthrough in the PR (each shortcut exercised).
- `cargo test` + CI green (view.rs untouched or changes covered by its pure tests).