### PR TITLE
remote: wire protocol — typed serde messages, versioned, panic-free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "ratatui",
  "regex",
  "rusqlite",
+ "serde",
  "serde_json",
  "tao",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ egui_extras = "0.36.1"
 ratatui = "0.30.2"
 regex = "1.13.1"
 rusqlite = { version = "0.40.2", features = ["bundled"] }
+serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod gui;
 pub mod login_item;
 pub mod menubar;
 pub mod notify;
+pub mod remote;
 pub mod render;
 pub mod roster;
 pub mod source;

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -1,0 +1,6 @@
+//! Wire protocol between a host `hermon` process and a remote agent (M10).
+//!
+//! This module owns only the message shapes and their line-delimited JSON
+//! encode/decode helpers — no I/O, no process spawning. See [`proto`].
+
+pub mod proto;

--- a/src/remote/proto.rs
+++ b/src/remote/proto.rs
@@ -1,0 +1,287 @@
+//! Typed, versioned wire messages for the host/agent protocol (#88).
+//!
+//! Transport is line-delimited JSON over stdio (one frame per line), wired
+//! up by later tickets (#89 agent, #90 host). This module only owns the
+//! message shapes and pure encode/decode helpers so both sides — and their
+//! tests — call the same functions.
+//!
+//! Decoding is panic-free and defensive, same philosophy as the renderers
+//! (`crate::render::claude::render_claude_line`): a line that isn't valid
+//! JSON, is truncated, or names a message type we don't recognise decodes
+//! to [`Decoded::ParseSkip`] instead of an `Err` or a panic. Unknown *fields*
+//! on an otherwise-valid message are silently ignored (serde's default
+//! behavior — pinned by a test in this module so `deny_unknown_fields` never
+//! creeps in and breaks forward compatibility).
+
+use serde::{Deserialize, Serialize};
+
+use crate::render::StyledLine;
+use crate::source::{Replay, SessionMeta};
+
+/// Wire protocol version this build speaks. Version *policy* (what to do on
+/// a mismatch) is the host's job in later tickets — this ticket only pins
+/// the constant and the fact that decoding never depends on its value.
+pub const PROTO_VERSION: u32 = 1;
+
+/// Messages sent from the remote agent to the host.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum AgentMsg {
+    /// Always the first line an agent sends.
+    Hello {
+        proto_version: u32,
+        hostname: String,
+        sources: Vec<String>,
+    },
+    /// A full snapshot of the agent's current sessions.
+    Snap { sessions: Vec<SessionMeta> },
+    /// New lines for a tail the host previously opened with `OpenTail`.
+    Tail { key: String, lines: Vec<StyledLine> },
+    /// The agent is closing the connection.
+    Bye { reason: String },
+}
+
+/// Messages sent from the host to a remote agent.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum HostCmd {
+    /// Start tailing one session, replaying `replay` worth of history first.
+    OpenTail { key: String, replay: Replay },
+    /// Stop tailing a session opened with `OpenTail`.
+    CloseTail { key: String },
+    /// Terminate the agent process.
+    Shutdown,
+}
+
+/// Result of decoding one line of the wire protocol: either a well-formed
+/// message, or a silent skip for anything hostile (garbage bytes, truncated
+/// JSON, an unrecognised message type). Never an `Err` — there is nothing
+/// for a caller to do with a decode failure except skip the line, so the
+/// type says that directly instead of via a `Result` a caller could
+/// `.unwrap()`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decoded<T> {
+    Msg(T),
+    ParseSkip,
+}
+
+/// Encode one [`AgentMsg`] as a single JSON line (no trailing newline).
+/// Serialization of these owned, plain-data structs cannot fail in
+/// practice, but the helper still never panics: it falls back to an empty
+/// string rather than unwrapping.
+pub fn encode_agent_msg(msg: &AgentMsg) -> String {
+    serde_json::to_string(msg).unwrap_or_default()
+}
+
+/// Decode one line of the wire protocol as an [`AgentMsg`]. Never panics:
+/// anything that isn't a valid, recognised `AgentMsg` decodes to
+/// [`Decoded::ParseSkip`].
+pub fn decode_agent_msg(line: &str) -> Decoded<AgentMsg> {
+    match serde_json::from_str::<AgentMsg>(line) {
+        Ok(msg) => Decoded::Msg(msg),
+        Err(_) => Decoded::ParseSkip,
+    }
+}
+
+/// Encode one [`HostCmd`] as a single JSON line (no trailing newline). See
+/// [`encode_agent_msg`] for the no-panic rationale.
+pub fn encode_host_cmd(cmd: &HostCmd) -> String {
+    serde_json::to_string(cmd).unwrap_or_default()
+}
+
+/// Decode one line of the wire protocol as a [`HostCmd`]. See
+/// [`decode_agent_msg`] for the no-panic contract.
+pub fn decode_host_cmd(line: &str) -> Decoded<HostCmd> {
+    match serde_json::from_str::<HostCmd>(line) {
+        Ok(cmd) => Decoded::Msg(cmd),
+        Err(_) => Decoded::ParseSkip,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::{Seg, Sem};
+    use crate::source::LastEvent;
+
+    fn sample_meta() -> SessionMeta {
+        SessionMeta {
+            id: "s1".into(),
+            started_at: 1.0,
+            ended: false,
+            model: "claude-sonnet-5".into(),
+            title: "t".into(),
+            in_tok: 10,
+            out_tok: 20,
+            cost: Some(0.5),
+            last_ts: 2.0,
+            turn_done: true,
+            tool_pending: false,
+            force_live: false,
+            last_tool: "Bash".into(),
+            last_line: "hi".into(),
+            last_event: Some(LastEvent::ToolUse("Bash".into())),
+        }
+    }
+
+    fn sample_line() -> StyledLine {
+        StyledLine(vec![
+            Seg::new(Sem::Bold, "▶ Bash"),
+            Seg::new(Sem::Plain, " ok"),
+        ])
+    }
+
+    // --- round trips: every AgentMsg variant ---
+
+    #[test]
+    fn round_trips_hello() {
+        let msg = AgentMsg::Hello {
+            proto_version: PROTO_VERSION,
+            hostname: "box".into(),
+            sources: vec!["claude".into(), "hermes".into()],
+        };
+        let line = encode_agent_msg(&msg);
+        assert_eq!(decode_agent_msg(&line), Decoded::Msg(msg));
+    }
+
+    #[test]
+    fn round_trips_snap() {
+        let msg = AgentMsg::Snap {
+            sessions: vec![sample_meta()],
+        };
+        let line = encode_agent_msg(&msg);
+        assert_eq!(decode_agent_msg(&line), Decoded::Msg(msg));
+    }
+
+    #[test]
+    fn round_trips_tail() {
+        let msg = AgentMsg::Tail {
+            key: "C:abcdef".into(),
+            lines: vec![sample_line()],
+        };
+        let line = encode_agent_msg(&msg);
+        assert_eq!(decode_agent_msg(&line), Decoded::Msg(msg));
+    }
+
+    #[test]
+    fn round_trips_bye() {
+        let msg = AgentMsg::Bye {
+            reason: "shutdown".into(),
+        };
+        let line = encode_agent_msg(&msg);
+        assert_eq!(decode_agent_msg(&line), Decoded::Msg(msg));
+    }
+
+    // --- round trips: every HostCmd variant ---
+
+    #[test]
+    fn round_trips_open_tail() {
+        let msg = HostCmd::OpenTail {
+            key: "C:abcdef".into(),
+            replay: Replay::DEFAULT,
+        };
+        let line = encode_host_cmd(&msg);
+        assert_eq!(decode_host_cmd(&line), Decoded::Msg(msg));
+    }
+
+    #[test]
+    fn round_trips_close_tail() {
+        let msg = HostCmd::CloseTail {
+            key: "C:abcdef".into(),
+        };
+        let line = encode_host_cmd(&msg);
+        assert_eq!(decode_host_cmd(&line), Decoded::Msg(msg));
+    }
+
+    #[test]
+    fn round_trips_shutdown() {
+        let msg = HostCmd::Shutdown;
+        let line = encode_host_cmd(&msg);
+        assert_eq!(decode_host_cmd(&line), Decoded::Msg(msg));
+    }
+
+    // --- hostile input: never a panic, always ParseSkip ---
+
+    #[test]
+    fn garbage_line_is_parse_skip() {
+        assert_eq!(decode_agent_msg("not json at all"), Decoded::ParseSkip);
+        assert_eq!(decode_host_cmd("not json at all"), Decoded::ParseSkip);
+    }
+
+    #[test]
+    fn empty_line_is_parse_skip() {
+        assert_eq!(decode_agent_msg(""), Decoded::ParseSkip);
+        assert_eq!(decode_host_cmd(""), Decoded::ParseSkip);
+    }
+
+    #[test]
+    fn truncated_json_is_parse_skip() {
+        let full = encode_agent_msg(&AgentMsg::Bye {
+            reason: "bye".into(),
+        });
+        let truncated = &full[..full.len() / 2];
+        assert_eq!(decode_agent_msg(truncated), Decoded::ParseSkip);
+    }
+
+    #[test]
+    fn unknown_message_type_is_parse_skip() {
+        assert_eq!(
+            decode_agent_msg(r#"{"type":"NotARealVariant"}"#),
+            Decoded::ParseSkip
+        );
+        assert_eq!(
+            decode_host_cmd(r#"{"type":"NotARealVariant"}"#),
+            Decoded::ParseSkip
+        );
+    }
+
+    #[test]
+    fn valid_json_wrong_shape_is_parse_skip() {
+        // Well-formed JSON, but neither an object with a "type" tag nor
+        // anything else AgentMsg/HostCmd can decode.
+        assert_eq!(decode_agent_msg("42"), Decoded::ParseSkip);
+        assert_eq!(decode_agent_msg("[1,2,3]"), Decoded::ParseSkip);
+        assert_eq!(decode_agent_msg("null"), Decoded::ParseSkip);
+    }
+
+    // --- forward compatibility ---
+
+    #[test]
+    fn unknown_extra_fields_are_ignored_not_rejected() {
+        // Pins serde's default "ignore unknown fields" behavior so nobody
+        // adds `#[serde(deny_unknown_fields)]` later and breaks forward
+        // compatibility with a newer agent/host.
+        let line = r#"{"type":"Bye","reason":"done","extra_field_from_the_future":123}"#;
+        assert_eq!(
+            decode_agent_msg(line),
+            Decoded::Msg(AgentMsg::Bye {
+                reason: "done".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn hello_with_future_proto_version_decodes_fine() {
+        // Version *policy* is the host's job in later tickets; decoding
+        // itself must not gate on the value.
+        let line = r#"{"type":"Hello","proto_version":999,"hostname":"h","sources":[]}"#;
+        assert_eq!(
+            decode_agent_msg(line),
+            Decoded::Msg(AgentMsg::Hello {
+                proto_version: 999,
+                hostname: "h".into(),
+                sources: vec![],
+            })
+        );
+    }
+
+    #[test]
+    fn open_tail_replay_round_trips() {
+        let msg = HostCmd::OpenTail {
+            key: "H:xyz".into(),
+            replay: Replay { bytes: 1, rows: 2 },
+        };
+        let line = encode_host_cmd(&msg);
+        assert_eq!(decode_host_cmd(&line), Decoded::Msg(msg));
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -20,6 +20,7 @@ pub mod opencode;
 
 use anyhow::{Result, anyhow};
 use chrono::DateTime;
+use serde::{Deserialize, Serialize};
 
 /// A 24-bit color, ready for `ratatui::style::Color::Rgb`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -48,7 +49,7 @@ pub const RED: Rgb = rgb(0xf7, 0x76, 0x8e);
 
 /// Semantic role of a run of text, replacing `hermon.py`'s raw escape codes
 /// (`hermon.py:55 BOLD/DIM/RED/...`).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Sem {
     /// Body text.
     Plain,
@@ -102,7 +103,7 @@ pub fn sanitize(text: &str) -> String {
 }
 
 /// A run of text carrying one semantic style.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Seg {
     pub sem: Sem,
     pub text: String,
@@ -118,7 +119,7 @@ impl Seg {
 }
 
 /// One logical output line, as a sequence of styled runs.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StyledLine(pub Vec<Seg>);
 
 impl StyledLine {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -5,12 +5,14 @@ pub mod claude;
 pub mod hermes;
 pub mod opencode;
 
+use serde::{Deserialize, Serialize};
+
 use crate::render::StyledLine;
 
 /// The last event observed in a session's transcript. Only the Claude
 /// source can populate this; DB-backed sources (Hermes, OpenCode) leave
 /// `SessionMeta::last_event` as `None`.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum LastEvent {
     /// A tool call with no result yet; carries the tool name.
     ToolUse(String),
@@ -21,7 +23,7 @@ pub enum LastEvent {
 
 /// Everything a source knows about one session, in the shared shape the
 /// roster and UI consume.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SessionMeta {
     pub id: String,
     pub started_at: f64,
@@ -89,7 +91,7 @@ pub trait Source {
 /// (Claude transcripts) honour `bytes` and ignore `rows`, database-backed
 /// ones (Hermes, OpenCode) do the reverse. A source may clamp either budget
 /// to whatever its store makes cheap.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Replay {
     /// Seek back at most this many bytes from the end of a transcript file.
     pub bytes: u64,


### PR DESCRIPTION
########## ISSUE #88 ##########
Wire protocol: typed serde messages, versioned, panic-free
Independent — no blockers. Foundation for #89–#93.
MODEL: sonnet5 — small surface but it's the contract every remote ticket builds on; forward-compat and panic-free decode semantics need to be pinned exactly right, with hostile tests.

**In plain terms:** Define the language the host and a remote hermon speak: typed, versioned messages for session snapshots and live tail lines.

---

**Why**
Everything in M10 hangs off this wire format. It gets its own ticket so it lands reviewed and tested before any transport code exists. Design decisions (made): line-delimited JSON over stdio; typed serde structs — the crate's "serde_json::Value only" rule applies to OTHER tools' hostile store schemas, not to a format we own.

**What to build**
Repo specifics: serde derive is NOT yet a dependency — this ticket adds it. `serde_json` is pinned `=1.0.151`; VERIFY on crates.io that the serde version you add is compatible with that pin before wiring (crate convention: never code against remembered APIs). The types getting derives live in `src/source/mod.rs` (`SessionMeta`, `LastEvent`) and `src/render/mod.rs` (`StyledLine`, `Seg`, `Sem`). `src/remote/` does not exist yet — create it (`mod remote;` declared wherever the other top-level modules are, see main.rs).
- Add `serde` (derive) as a dependency; derive `Serialize`/`Deserialize` on `SessionMeta`, `LastEvent`, `StyledLine`, `Seg`, `Sem` (verify nothing about the existing pure-render contract changes — these are additive derives).
- `src/remote/proto.rs` (new `src/remote/` module):
  - `AgentMsg` (agent → host): `Hello { proto_version: u32, hostname: String, sources: Vec<String> }` (first line, always), `Snap { sessions: Vec<SessionMeta> }`, `Tail { key: String, lines: Vec<StyledLine> }`, `Bye { reason: String }`.
  - `HostCmd` (host → agent): `OpenTail { key, replay }`, `CloseTail { key }`, `Shutdown`.
  - `pub const PROTO_VERSION: u32 = 1;`
- One frame per line, `serde_json` encode/decode helpers that never panic: a malformed line decodes to a `ParseSkip` variant (same defensive philosophy as the renderers).
- Forward compatibility: unknown fields ignored on decode (serde default behavior — pin it with a test so nobody adds `deny_unknown_fields` later); unknown message types → `ParseSkip`, not an error.
- Note `Replay` (source/mod.rs) rides inside `OpenTail` — it needs derives too if it doesn't have them.

Seam note: #89 (agent) encodes `AgentMsg` and decodes `HostCmd`; #90 (host) does the reverse — keep the encode/decode helpers pure (`&str` in, `String`/enum out, zero I/O) so both sides and their tests call the same functions. #95 lands in the same wave and adds a `sanitize` choke point in `src/render/mod.rs` — the same file your derives touch. Touch only your derive/annotation lines; the textual conflict is expected and resolved at merge.

**Out of scope**
Any I/O, process spawning, or transport.

**Acceptance criteria**
- Round-trip tests for every message; hostile-input tests (garbage line, truncated JSON, unknown type, extra fields) all yield `ParseSkip`/ignored-field behavior, never a panic.
- A `Hello` with `proto_version: 999` decodes fine (version POLICY is the host's job, next tickets).
- `cargo test` + CI green (clippy -D warnings, fmt).