### PR TITLE
security: strip terminal control sequences at the render boundary

### DIFF
--- a/src/notify.rs
+++ b/src/notify.rs
@@ -16,7 +16,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use crate::render::fmt_elapsed;
+use crate::render::{fmt_elapsed, sanitize};
 use crate::source::{Attn, Liveness};
 
 /// Why a session went from not-done to done. Only [`DoneCause::TurnDone`]
@@ -250,7 +250,7 @@ pub fn decide_alerts(
             {
                 alerts.push(Alert {
                     key: t.key.clone(),
-                    label: t.label.clone(),
+                    label: sanitize(&t.label),
                     kind: AlertKind::TurnDone,
                     detail: format!(
                         "{} · {}",
@@ -267,9 +267,9 @@ pub fn decide_alerts(
         {
             alerts.push(Alert {
                 key: t.key.clone(),
-                label: t.label.clone(),
+                label: sanitize(&t.label),
                 kind: AlertKind::Error,
-                detail: line.clone(),
+                detail: sanitize(line),
             });
         }
 
@@ -283,11 +283,11 @@ pub fn decide_alerts(
             {
                 alerts.push(Alert {
                     key: t.key.clone(),
-                    label: t.label.clone(),
+                    label: sanitize(&t.label),
                     kind,
                     detail: format!(
                         "tool `{}` pending {}",
-                        t.last_tool,
+                        sanitize(&t.last_tool),
                         fmt_elapsed(Some(now - t.state_since))
                     ),
                 });
@@ -372,15 +372,14 @@ pub(crate) fn applescript_escape(s: &str) -> String {
 }
 
 /// The `osascript -e` argument for one banner. A session title is untrusted
-/// text — it can contain `"`, `\`, or a fragment like `"; do shell script
-/// "…` aimed at escaping the string literal — so every field is escaped the
-/// same way regardless of source.
+/// text — it can contain `"`, `\`, or terminal control sequences, so every
+/// field is sanitized and escaped for both control sequences and AppleScript syntax.
 fn build_osascript(title: &str, subtitle: &str, body: &str) -> String {
     format!(
         "display notification \"{}\" with title \"{}\" subtitle \"{}\"",
-        applescript_escape(body),
-        applescript_escape(title),
-        applescript_escape(subtitle)
+        applescript_escape(&sanitize(body)),
+        applescript_escape(&sanitize(title)),
+        applescript_escape(&sanitize(subtitle))
     )
 }
 
@@ -391,16 +390,19 @@ fn build_osascript(title: &str, subtitle: &str, body: &str) -> String {
 /// tick. A failed spawn is swallowed the same way — a missing or broken
 /// notifier degrades to no banner, not a crash.
 pub fn deliver(notifier: &Notifier, title: &str, subtitle: &str, body: &str) {
+    let title = sanitize(title);
+    let subtitle = sanitize(subtitle);
+    let body = sanitize(body);
     let mut cmd = match notifier {
         Notifier::TerminalNotifier(bin) => {
             let mut cmd = Command::new(bin);
             cmd.args([
                 "-title",
-                title,
+                &title,
                 "-subtitle",
-                subtitle,
+                &subtitle,
                 "-message",
-                body,
+                &body,
                 "-sound",
                 "default",
             ]);
@@ -408,7 +410,7 @@ pub fn deliver(notifier: &Notifier, title: &str, subtitle: &str, body: &str) {
         }
         Notifier::Osascript(bin) => {
             let mut cmd = Command::new(bin);
-            cmd.args(["-e", &build_osascript(title, subtitle, body)]);
+            cmd.args(["-e", &build_osascript(&title, &subtitle, &body)]);
             cmd
         }
         Notifier::NotifySend(bin) => {
@@ -418,7 +420,7 @@ pub fn deliver(notifier: &Notifier, title: &str, subtitle: &str, body: &str) {
             } else {
                 format!("{subtitle}\n{body}")
             };
-            cmd.args([title, &full_body]);
+            cmd.args([&title, &full_body]);
             cmd
         }
         Notifier::Silent => return,
@@ -621,6 +623,51 @@ mod delivery_tests {
             script,
             "display notification \"bo\\\"dy\" with title \"ti\\\"tle\" subtitle \"sub\\\\title\""
         );
+    }
+
+    #[test]
+    fn build_osascript_sanitizes_control_sequences_in_title() {
+        let script = build_osascript("title\x1b]0;hack\x07ed", "sub", "body");
+        // Should not contain raw ESC or BEL bytes, only escaped replacement chars
+        assert!(!script.contains('\x1b'));
+        assert!(!script.contains('\x07'));
+    }
+
+    #[test]
+    fn deliver_terminal_notifier_receives_sanitized_fields() {
+        let out = tempfile::tempdir().unwrap();
+        let out_file = out.path().join("argv.txt");
+        let dir = shim_dir("terminal-notifier", &out_file);
+        let notifier = Notifier::TerminalNotifier(dir.path().join("terminal-notifier"));
+
+        deliver(
+            &notifier,
+            "title\x1b]0;hack\x07",
+            "sub\x00tle",
+            "body\x1bcode",
+        );
+
+        let got = read_eventually(&out_file);
+        // Should not contain raw control bytes in the arguments
+        assert!(!got.contains('\x1b'));
+        assert!(!got.contains('\x00'));
+    }
+
+    #[test]
+    fn deliver_osascript_receives_sanitized_and_escaped_fields() {
+        let out = tempfile::tempdir().unwrap();
+        let out_file = out.path().join("argv.txt");
+        let dir = shim_dir("osascript", &out_file);
+        let notifier = Notifier::Osascript(dir.path().join("osascript"));
+
+        deliver(&notifier, "hostile\x1b]0;title\x07", "subtitle", "body");
+
+        let got = read_eventually(&out_file);
+        // The script should be well-formed and contain sanitized content
+        assert!(got.contains("display notification"));
+        // No raw escape or control bytes should reach the shell
+        assert!(!got.contains('\x1b'));
+        assert!(!got.contains('\x00'));
     }
 }
 
@@ -939,5 +986,66 @@ mod tests {
 
         let alerts = decide_alerts(&[tr_err, tr_stuck, tr_perm], 0.0, &cfg, &mut hist);
         assert!(alerts.is_empty());
+    }
+
+    #[test]
+    fn hostile_error_line_is_sanitized() {
+        let mut hist = AlertHistory::new();
+        boot(&mut hist);
+        let mut tr = t("k1", Liveness::Live, Liveness::Live);
+        tr.error_line = Some("error\x1b]0;pwned\x07text".to_string());
+        let alerts = decide_alerts(&[tr], 0.0, &NotifyCfg::default(), &mut hist);
+        assert_eq!(alerts.len(), 1);
+        let detail = &alerts[0].detail;
+        // Check no control bytes in alert detail
+        for b in detail.as_bytes() {
+            assert!(
+                *b >= 0x20 || *b == 0x0A,
+                "alert detail contains control byte 0x{:02x}",
+                b
+            );
+        }
+    }
+
+    #[test]
+    fn hostile_label_is_sanitized() {
+        let mut hist = AlertHistory::new();
+        boot(&mut hist);
+        let mut tr = t("k1", Liveness::Live, Liveness::Done);
+        tr.done_cause = Some(DoneCause::TurnDone);
+        tr.started_at = -20.0;
+        tr.label = "Session\x1b]0;hack\x07ed".to_string();
+        let alerts = decide_alerts(&[tr], 0.0, &NotifyCfg::default(), &mut hist);
+        assert_eq!(alerts.len(), 1);
+        let label = &alerts[0].label;
+        // Check no control bytes in alert label
+        for b in label.as_bytes() {
+            assert!(
+                *b >= 0x20 || *b == 0x0A,
+                "alert label contains control byte 0x{:02x}",
+                b
+            );
+        }
+    }
+
+    #[test]
+    fn hostile_tool_name_in_alert_detail_is_sanitized() {
+        let mut hist = AlertHistory::new();
+        boot(&mut hist);
+        let tr = t("k1", Liveness::Live, Liveness::Attention(Attn::Stuck));
+        let mut tr = tr;
+        tr.state_since = 0.0;
+        tr.last_tool = "bash\x1b]0;pwned\x07".to_string();
+        let alerts = decide_alerts(&[tr], 900.0, &NotifyCfg::default(), &mut hist);
+        assert_eq!(alerts.len(), 1);
+        let detail = &alerts[0].detail;
+        // Check no control bytes in alert detail
+        for b in detail.as_bytes() {
+            assert!(
+                *b >= 0x20 || *b == 0x0A,
+                "alert detail with hostile tool name contains control byte 0x{:02x}",
+                b
+            );
+        }
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5,6 +5,14 @@
 //! `hermon ls`, which prints [`StyledLine::to_plain`]. Line wrapping belongs
 //! to the pane widget; renderers emit logical lines and use [`clip`] only for
 //! content truncation.
+//!
+//! **Security: Terminal control sanitization.** The render boundary operates
+//! under a defensive contract that extends beyond JSON shape to text content:
+//! [`to_plain()`](StyledLine::to_plain) output contains no byte < 0x20 except
+//! newline (0x0A). Control sequences (ANSI/OSC, C0/C1, ESC) are stripped at
+//! the [`Seg::new`] choke point and replaced with a visible placeholder
+//! (`U+FFFD`), making hostile or malformed bytes visible rather than silent.
+//! This applies uniformly to all sources (local and future remote agents).
 
 pub mod claude;
 pub mod hermes;
@@ -75,6 +83,24 @@ impl Sem {
     }
 }
 
+/// Strips terminal control sequences from text, making them visible as placeholders.
+/// Replaces C0 controls (0x00-0x1F except 0x0A for newline), C1 controls (0x80-0x9F),
+/// with U+FFFD (replacement character). Newlines are preserved; all other control bytes
+/// become visible, foiling ANSI/OSC injection attempts.
+pub fn sanitize(text: &str) -> String {
+    text.chars()
+        .map(|c| {
+            let code = c as u32;
+            // C0 controls except newline (0x0A): 0x00-0x09, 0x0B-0x1F, and C1: 0x80-0x9F
+            if (code <= 0x09 || (0x0B..=0x1F).contains(&code)) || (0x80..=0x9F).contains(&code) {
+                '\u{FFFD}' // U+FFFD REPLACEMENT CHARACTER
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
 /// A run of text carrying one semantic style.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Seg {
@@ -86,7 +112,7 @@ impl Seg {
     pub fn new(sem: Sem, text: impl Into<String>) -> Self {
         Seg {
             sem,
-            text: text.into(),
+            text: sanitize(&text.into()),
         }
     }
 }
@@ -286,6 +312,121 @@ mod tests {
             "2026-13-40T99:00:00Z",
         ] {
             assert!(parse_ts(bad).is_err(), "expected Err for {bad:?}");
+        }
+    }
+
+    // ---------------------------------------------------- sanitize tests
+
+    #[test]
+    fn sanitize_keeps_normal_text() {
+        assert_eq!(sanitize("hello world"), "hello world");
+        assert_eq!(sanitize("Claude 3.5"), "Claude 3.5");
+        assert_eq!(sanitize("café"), "café");
+    }
+
+    #[test]
+    fn sanitize_keeps_newlines() {
+        assert_eq!(sanitize("line1\nline2"), "line1\nline2");
+    }
+
+    #[test]
+    fn sanitize_removes_null_byte() {
+        assert_eq!(sanitize("before\x00after"), "before\u{FFFD}after");
+    }
+
+    #[test]
+    fn sanitize_removes_tab() {
+        assert_eq!(sanitize("col1\tcol2"), "col1\u{FFFD}col2");
+    }
+
+    #[test]
+    fn sanitize_removes_c0_controls() {
+        // BEL (0x07), BS (0x08), VT (0x0B), FF (0x0C), CR (0x0D)
+        assert_eq!(sanitize("x\x07y"), "x\u{FFFD}y"); // BEL
+        assert_eq!(sanitize("x\x08y"), "x\u{FFFD}y"); // BS
+        assert_eq!(sanitize("x\x0by"), "x\u{FFFD}y"); // VT
+        assert_eq!(sanitize("x\x0cy"), "x\u{FFFD}y"); // FF
+        assert_eq!(sanitize("x\x0dy"), "x\u{FFFD}y"); // CR
+    }
+
+    #[test]
+    fn sanitize_removes_esc() {
+        assert_eq!(sanitize("hello\x1bworld"), "hello\u{FFFD}world");
+    }
+
+    #[test]
+    fn sanitize_removes_c1_controls() {
+        // C1 range: 0x80-0x9F — use char::from_u32 to construct them
+        if let Some(c80) = char::from_u32(0x80) {
+            let s = format!("x{}y", c80);
+            assert_eq!(sanitize(&s), "x\u{FFFD}y");
+        }
+        if let Some(c9f) = char::from_u32(0x9F) {
+            let s = format!("x{}y", c9f);
+            assert_eq!(sanitize(&s), "x\u{FFFD}y");
+        }
+    }
+
+    #[test]
+    fn sanitize_osc_52_clipboard_attack() {
+        // OSC 52 sequence: ESC ] 52 ; c ; data BEL
+        // Only ESC (0x1B) and BEL (0x07) are control bytes that get replaced
+        let hostile = "text\x1b]52;c;Y2lhbmV0\x07more";
+        assert_eq!(sanitize(hostile), "text\u{FFFD}]52;c;Y2lhbmV0\u{FFFD}more");
+    }
+
+    #[test]
+    fn sanitize_osc_0_title_attack() {
+        // OSC 0 sequence: ESC ] 0 ; title BEL
+        // Only ESC (0x1B) and BEL (0x07) are control bytes
+        let hostile = "prefix\x1b]0;pwned\x07suffix";
+        assert_eq!(sanitize(hostile), "prefix\u{FFFD}]0;pwned\u{FFFD}suffix");
+    }
+
+    #[test]
+    fn sanitize_csi_sequence() {
+        // CSI sequence: ESC [ ... m (e.g., color code)
+        // Only ESC (0x1B) is a control byte
+        let hostile = "before\x1b[1;31mafter";
+        assert_eq!(sanitize(hostile), "before\u{FFFD}[1;31mafter");
+    }
+
+    #[test]
+    fn sanitize_to_plain_is_printable_only() {
+        let line = StyledLine(vec![
+            Seg::new(Sem::Bold, "prefix\x1b]0;pwned\x07middle"),
+            Seg::new(Sem::Plain, "normal\x00text"),
+            Seg::new(Sem::Error, "error\x1bcode"),
+        ]);
+        let plain = line.to_plain();
+        // Check no byte < 0x20 except newline
+        for b in plain.as_bytes() {
+            assert!(
+                *b >= 0x20 || *b == 0x0A,
+                "found control byte 0x{:02x} in to_plain output",
+                b
+            );
+        }
+    }
+
+    #[test]
+    fn seg_constructor_sanitizes() {
+        let seg = Seg::new(Sem::Plain, "text\x1bESC");
+        assert_eq!(seg.text, "text\u{FFFD}ESC");
+    }
+
+    #[test]
+    fn hostile_session_title_is_neutralized_in_roster() {
+        // Session title with control sequences
+        let hostile_title = "Session\x1b]0;hacked\x07Title";
+        let seg = Seg::new(Sem::Plain, hostile_title);
+        let plain = seg.text;
+        for b in plain.as_bytes() {
+            assert!(
+                *b >= 0x20 || *b == 0x0A,
+                "session title not neutralized: 0x{:02x}",
+                b
+            );
         }
     }
 }

--- a/src/roster.rs
+++ b/src/roster.rs
@@ -16,7 +16,7 @@ use anyhow::anyhow;
 use chrono::{DateTime, Local};
 use regex::Regex;
 
-use crate::render::{Seg, Sem, StyledLine, clip, fmt_elapsed, short_id};
+use crate::render::{Seg, Sem, StyledLine, clip, fmt_elapsed, sanitize, short_id};
 use crate::source::claude::ClaudeSource;
 use crate::source::hermes::HermesSource;
 use crate::source::opencode::OpenCodeSource;
@@ -164,9 +164,9 @@ fn roster_row(
         id: s.id.clone(),
         key: format!("{label_prefix}:{}", short_id(&s.id)),
         state,
-        model: s.model.clone(),
-        last_tool,
-        last_line: s.last_line.clone(),
+        model: sanitize(&s.model),
+        last_tool: sanitize(&last_tool),
+        last_line: sanitize(&s.last_line),
         in_tok: s.in_tok,
         out_tok: s.out_tok,
         cost: s.cost,
@@ -174,7 +174,7 @@ fn roster_row(
         // means the elapsed column has nothing to say.
         elapsed: (s.started_at > 0.0).then_some(s.last_ts - s.started_at),
         last_ts: s.last_ts,
-        title: s.title.clone(),
+        title: sanitize(&s.title),
         attn_elapsed: None,
     })
 }


### PR DESCRIPTION
########## ISSUE #95 ##########
Security: strip terminal control sequences at the render boundary (all sources)
Independent — no blockers. MUST MERGE BEFORE #90: every remote ticket's security addendum requires this sanitizer running host-side.
MODEL: haiku4.5 — a single-choke-point pure function with sharply enumerated hostile fixtures; the design decisions (where, what, placeholder) are already made in the ticket.

**In plain terms:** Agent output can contain invisible terminal control codes that retitle your terminal, write your clipboard, or corrupt the display. Strip them everywhere, for every source — this is a pre-existing gap that remote agents (M10) will amplify.

---

**Why**
The renderers' defensive contract covers JSON *shape* (never panic, `· parse-skip`), not *content*: a transcript line whose text embeds raw ANSI/OSC sequences flows through `StyledLine` untouched and reaches the terminal via `hermon ls`, `hermon render`, and the TUI. Agents log whatever tools and webpages emit, so hostile bytes in local transcripts are already possible today; M10 adds a channel where the entire stream may be adversarial (a compromised container's agent). Known real-world payloads: OSC 52 clipboard writes, window retitling, cursor-position lies; historically worse on older terminals.

**What to build**
Repo specifics: the render contract lives in `src/render/mod.rs` (`StyledLine { key, lines: Vec<Seg> }`, `Seg { text, style: Sem }`, `Sem`); the three renderers (`render/claude.rs`, `render/hermes.rs`, `render/opencode.rs`) all build `Seg`s. Roster cells come from `roster.rs` `RosterRow` (title, model, last_line — populated from `SessionMeta` in `source/mod.rs`); notification bodies from `notify.rs` (the #44 AppleScript escaping handles quoting, not control chars — layer both).
- One sanitization function at the render boundary in `src/render/mod.rs`: `sanitize(text) -> String` replacing C0 controls (except `\n`/`\t` where segments legitimately keep them — check call sites; likely nothing does), C1 controls, and ESC (0x1B) with a visible placeholder (`�` or `^[`). Applied where text ENTERS `Seg` — one choke point, not per-renderer: the `Seg` constructor is the right place if all text flows through it (verify; if raw struct literals exist in the three renderers or tests, route them through the constructor).
- Applies identically to every source (local Claude/Hermes/OpenCode and M10's `RemoteSource` — the remote's `Tail`/`Snap` strings must pass through the same choke point on the host side, since a hostile agent can bypass its own sanitizer).
- Also cover the non-Seg text paths: pane titles, roster cells (session titles, model strings, `last_line`), notification bodies.
- Keep `to_plain()` output printable-only by construction afterward; document the guarantee in the module doc as an extension of the defensive contract.

Seam note: #90 (RemoteSource) is REQUIRED by its security addendum to route every remote-supplied string (tail text, session titles, models, last_line, Hello hostname) through this exact choke point on the host. Make `sanitize` a small `pub` pure function so #90 can call it directly for non-Seg strings; don't bury it in a private constructor path only. Heads-up: #88 lands in the same wave and adds serde derives to `StyledLine`/`Seg`/`Sem` in this same file — touch only your sanitization change; the textual merge conflict is expected and handled at merge time.

**Out of scope**
Unicode confusables/bidi trickery (display-spoofing, not code-exec class — note as future work in the module doc). Width handling.

**Acceptance criteria**
- Tests: a transcript line embedding `\x1b]0;pwned\x07` (title), `\x1b]52;c;…\x07` (OSC 52), CSI sequences, raw C0 bytes, and a lone ESC — all render as visible placeholders in `to_plain()` and in a TestBackend snapshot; nothing panics.
- Grep-proof: `to_plain()` output over the entire hostile fixture set contains no byte < 0x20 except `\n`.
- A hostile session *title* is neutralized in roster cells and in the notification body path.
- `cargo test` + CI green (clippy -D warnings, fmt).