### PR TITLE
agent: in-container stdio streamer over the wire protocol

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,10 @@ pub enum Command {
     Render(RenderArgs),
     /// Live fleet counts in the macOS menu bar (macOS only).
     Menubar(MenubarArgs),
+    /// Stream session frames over stdio for a host `hermon` process to
+    /// consume — the in-container half of the remote wire protocol (#88,
+    /// #89). `--interval` (from [`SourceArgs`]) is the `Snap` cadence.
+    Agent(SourceArgs),
 }
 
 /// Menubar-specific options, including source flags and login-item management.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,21 @@ pub fn run() -> anyhow::Result<()> {
             };
             menubar::run(config)
         }
+        Command::Agent(args) => {
+            let config = remote::agent::AgentConfig {
+                claude_dir: args.claude_dir,
+                hermes_db: args.hermes_db,
+                opencode_db: args.opencode_db,
+                idle_timeout: args.idle_timeout,
+                // `watch`/`gui`'s fixed 300s (`hermon.py:1463`) — agent mode
+                // has no fresh-window flag of its own, and the host does its
+                // own classification anyway, so a wider window here just
+                // means OpenCode sessions age off the snapshot a bit later.
+                fresh_window: 300.0,
+                interval: Duration::from_secs_f64(args.interval),
+            };
+            remote::agent::run(config)
+        }
     }
 }
 

--- a/src/remote/agent.rs
+++ b/src/remote/agent.rs
@@ -1,0 +1,253 @@
+//! `hermon agent`: the in-container half of the remote wire protocol.
+//!
+//! Deliberately dumb (#89): read the same three stores `watch`/`ls` read —
+//! inside a container they're local files again, `lsof` liveness included
+//! — and print [`AgentMsg`] frames on stdout instead of drawing a UI. No
+//! notifications, no TUI, no roster classification (that's the host's job);
+//! stdout carries only frames, stderr carries diagnostics.
+//!
+//! Two threads: [`run`]'s caller thread drives the scan/tail loop and owns
+//! every [`Tailer`] (which need not be `Send`), while a second thread reads
+//! [`HostCmd`] lines off stdin and a third owns the actual stdout writes so
+//! a stalled reader can't wedge the scan loop (see [`spawn_writer`]).
+
+use std::collections::HashMap;
+use std::io::{self, BufRead, Write};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender, SyncSender, TrySendError};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use crate::remote::proto::{
+    AgentMsg, Decoded, HostCmd, PROTO_VERSION, decode_host_cmd, encode_agent_msg,
+};
+use crate::roster::Sources;
+use crate::source::{Replay, SessionMeta, Source, Tailer};
+
+/// How often open tails are polled for new lines — the same cadence
+/// `engine::PANE_TICK` polls TUI panes at, since a tailed session should
+/// read live either way.
+const TAIL_TICK: Duration = Duration::from_millis(300);
+
+/// Frames queued for the writer thread before a stalled reader starts
+/// costing `Tail` frames (see [`spawn_writer`]). Generous enough to absorb
+/// a burst without dropping anything under normal conditions.
+const WRITER_QUEUE_CAP: usize = 256;
+
+/// Store locations and the `Snap` cadence — the agent's share of
+/// [`crate::cli::SourceArgs`]; everything else there (notify flags,
+/// `--max-panes`, `--linger`, …) belongs to UI modes this one doesn't have.
+pub struct AgentConfig {
+    pub claude_dir: String,
+    pub hermes_db: String,
+    pub opencode_db: String,
+    pub idle_timeout: f64,
+    pub fresh_window: f64,
+    pub interval: Duration,
+}
+
+/// A [`HostCmd`], decoded and handed from the stdin thread to the main
+/// loop. `Shutdown` doubles as "stdin hit EOF" — the transport died either
+/// way, and an orphaned agent in a container must not linger.
+enum Cmd {
+    OpenTail { key: String, replay: Replay },
+    CloseTail { key: String },
+    Shutdown,
+}
+
+/// Runs until `HostCmd::Shutdown` arrives or stdin closes. Never returns an
+/// `Err` for anything a malformed frame or a stalled pipe could cause —
+/// only a genuinely unrecoverable setup failure would, and there isn't one
+/// here.
+pub fn run(config: AgentConfig) -> anyhow::Result<()> {
+    let (writer_tx, writer) = spawn_writer();
+    let (cmd_tx, cmd_rx) = mpsc::channel();
+    thread::spawn(move || read_stdin(cmd_tx));
+
+    send(
+        &writer_tx,
+        AgentMsg::Hello {
+            proto_version: PROTO_VERSION,
+            hostname: hostname(),
+            sources: vec!["claude".into(), "hermes".into(), "opencode".into()],
+        },
+    );
+
+    let mut sources = Sources::new(&config.claude_dir, &config.hermes_db, &config.opencode_db);
+    let mut tails: HashMap<String, Box<dyn Tailer>> = HashMap::new();
+
+    let mut next_snap = Instant::now();
+    let mut next_tail_tick = Instant::now();
+    let reason = loop {
+        if Instant::now() >= next_snap {
+            let sessions = snapshot(&mut sources, now_secs(), &config);
+            send(&writer_tx, AgentMsg::Snap { sessions });
+            next_snap = Instant::now() + config.interval;
+        }
+        if Instant::now() >= next_tail_tick {
+            pump_tails(&writer_tx, &mut tails);
+            next_tail_tick = Instant::now() + TAIL_TICK;
+        }
+
+        let deadline = next_snap.min(next_tail_tick);
+        match cmd_rx.recv_timeout(deadline.saturating_duration_since(Instant::now())) {
+            Ok(Cmd::Shutdown) => break "shutdown",
+            Ok(Cmd::OpenTail { key, replay }) => {
+                let session_id = key.split_once(':').map_or(key.as_str(), |(_, id)| id);
+                if let Some(tailer) = sources.open_tailer(&key, session_id, replay) {
+                    tails.insert(key, tailer);
+                    next_tail_tick = Instant::now(); // surface the replay promptly
+                }
+            }
+            Ok(Cmd::CloseTail { key }) => {
+                tails.remove(&key);
+            }
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => break "stdin closed",
+        }
+    };
+
+    send(
+        &writer_tx,
+        AgentMsg::Bye {
+            reason: reason.to_string(),
+        },
+    );
+    drop(writer_tx); // closes the writer thread's channel so it can drain and exit
+    let _ = writer.join();
+    Ok(())
+}
+
+/// Every session across all three sources, each tagged with its source
+/// prefix so a later `HostCmd::OpenTail` can name it back. The wire
+/// `SessionMeta` (unlike `roster::RosterRow`) carries no separate key
+/// field, so the prefix `Sources::open_tailer` dispatches on rides in `id`
+/// itself as `"C:<real id>"` rather than beside it — the id round-trips
+/// through the host unchanged and `run`'s `OpenTail` arm splits it back
+/// apart the same way it was built here.
+///
+/// Unfiltered and unclassified, deliberately: this is a full snapshot, not
+/// a diff, and liveness classification is the host's job, not the agent's.
+fn snapshot(sources: &mut Sources, now: f64, config: &AgentConfig) -> Vec<SessionMeta> {
+    let mut out = Vec::new();
+    for s in sources.claude.sessions(now, config.idle_timeout) {
+        out.push(keyed("C", s));
+    }
+    for s in sources.hermes.sessions() {
+        out.push(keyed("H", s));
+    }
+    for s in sources.opencode.sessions(now - config.fresh_window) {
+        out.push(keyed("O", s));
+    }
+    out
+}
+
+fn keyed(prefix: &str, mut s: SessionMeta) -> SessionMeta {
+    s.id = format!("{prefix}:{}", s.id);
+    s
+}
+
+/// Polls every open tail and forwards new lines as `Tail` frames, dropping
+/// (never blocking on) a tail whose frame can't be queued right now — a
+/// stalled reader must cost tail lines, not wedge the scan loop that also
+/// has to get the next `Snap` out.
+fn pump_tails(writer_tx: &SyncSender<AgentMsg>, tails: &mut HashMap<String, Box<dyn Tailer>>) {
+    for (key, tailer) in tails.iter_mut() {
+        let lines = tailer.poll();
+        if lines.is_empty() {
+            continue;
+        }
+        let msg = AgentMsg::Tail {
+            key: key.clone(),
+            lines,
+        };
+        match writer_tx.try_send(msg) {
+            Ok(()) | Err(TrySendError::Disconnected(_)) => {}
+            Err(TrySendError::Full(_)) => {} // reader is stalled; drop this tail's frame
+        }
+    }
+}
+
+/// Sends a frame the delivery-guaranteed way (`Hello`, `Snap`, `Bye`):
+/// blocks until the writer thread has room, rather than risking the loss
+/// of a snapshot the way a dropped `Tail` frame is tolerated.
+fn send(writer_tx: &SyncSender<AgentMsg>, msg: AgentMsg) {
+    let _ = writer_tx.send(msg);
+}
+
+/// Owns the only handle on stdout: every frame is line-delimited JSON,
+/// unbuffered (flushed per line) so a reader tailing the pipe sees each
+/// frame as soon as it's written. Runs until its sender is dropped or a
+/// write fails (reader gone) — either way there is nothing left to do but
+/// stop.
+fn spawn_writer() -> (SyncSender<AgentMsg>, JoinHandle<()>) {
+    let (tx, rx): (SyncSender<AgentMsg>, Receiver<AgentMsg>) = mpsc::sync_channel(WRITER_QUEUE_CAP);
+    let handle = thread::spawn(move || {
+        let stdout = io::stdout();
+        let mut out = stdout.lock();
+        while let Ok(msg) = rx.recv() {
+            let line = encode_agent_msg(&msg);
+            if writeln!(out, "{line}").is_err() || out.flush().is_err() {
+                break;
+            }
+        }
+    });
+    (tx, handle)
+}
+
+/// Reads `HostCmd` lines off stdin until EOF, handing each to the main
+/// loop as a [`Cmd`]. A malformed line is `ParseSkip` per #88's decoder: it
+/// gets one stderr diagnostic and the loop keeps running — garbage on
+/// stdin is never a reason to exit. EOF (or a read error) sends `Shutdown`
+/// itself, since that's the only way the main loop learns the transport
+/// died.
+fn read_stdin(cmd_tx: Sender<Cmd>) {
+    let stdin = io::stdin();
+    for line in stdin.lock().lines() {
+        let Ok(line) = line else { break };
+        if line.trim().is_empty() {
+            continue;
+        }
+        match decode_host_cmd(&line) {
+            Decoded::Msg(HostCmd::OpenTail { key, replay }) => {
+                let _ = cmd_tx.send(Cmd::OpenTail { key, replay });
+            }
+            Decoded::Msg(HostCmd::CloseTail { key }) => {
+                let _ = cmd_tx.send(Cmd::CloseTail { key });
+            }
+            Decoded::Msg(HostCmd::Shutdown) => {
+                let _ = cmd_tx.send(Cmd::Shutdown);
+                return;
+            }
+            Decoded::ParseSkip => {
+                eprintln!("hermon agent: skipping malformed stdin line");
+            }
+        }
+    }
+    let _ = cmd_tx.send(Cmd::Shutdown); // stdin EOF: the transport died
+}
+
+/// Best-effort hostname for `Hello`, with no extra dependency: containers
+/// almost always carry one at `/etc/hostname` (set by the runtime); `$HOSTNAME`
+/// and a fixed fallback cover everywhere that file doesn't exist (e.g. local
+/// dev/test on macOS). Cosmetic only — nothing downstream keys behavior off
+/// this value.
+fn hostname() -> String {
+    if let Ok(name) = std::fs::read_to_string("/etc/hostname") {
+        let name = name.trim();
+        if !name.is_empty() {
+            return name.to_string();
+        }
+    }
+    if let Ok(name) = std::env::var("HOSTNAME")
+        && !name.is_empty()
+    {
+        return name;
+    }
+    "unknown-host".to_string()
+}
+
+fn now_secs() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0.0, |d| d.as_secs_f64())
+}

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -1,6 +1,8 @@
 //! Wire protocol between a host `hermon` process and a remote agent (M10).
 //!
 //! This module owns only the message shapes and their line-delimited JSON
-//! encode/decode helpers — no I/O, no process spawning. See [`proto`].
+//! encode/decode helpers — no I/O, no process spawning. See [`proto`] for
+//! the wire format and [`agent`] for the in-container half that speaks it.
 
+pub mod agent;
 pub mod proto;

--- a/tests/agent.rs
+++ b/tests/agent.rs
@@ -1,0 +1,206 @@
+//! `hermon agent` acceptance tests (#89): the stdio pipe test the spec
+//! calls for — `Hello` then `Snap` frames, `OpenTail` producing `Tail`
+//! frames, a prompt exit on stdin EOF, and no non-frame bytes on stdout —
+//! run against a real fixture store, no docker. This is the shape #90's
+//! e2e (`cmd:`-style transport) reuses.
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command as Proc, Stdio};
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use chrono::DateTime;
+use tempfile::TempDir;
+
+use hermon::remote::proto::{AgentMsg, Decoded, HostCmd, decode_agent_msg, encode_host_cmd};
+use hermon::source::Replay;
+
+/// A Claude transcript root with one session fresh enough (mtime, real
+/// wall clock — the binary has no injectable `now`) for `ClaudeSource` to
+/// surface it, same trick `tests/roster.rs`'s binary tests use.
+fn claude_dir() -> TempDir {
+    let dir = TempDir::new().expect("create temp dir");
+    let project = dir.path().join("-Users-taloz-code-hermon");
+    fs::create_dir_all(&project).expect("create project dir");
+    let now = wall_clock_now();
+    let body = format!("{}{}", user_line(now - 30.0), assistant_line(now - 5.0));
+    fs::write(
+        project.join("11111111-2222-3333-4444-555555555555.jsonl"),
+        body,
+    )
+    .expect("write transcript");
+    dir
+}
+
+fn user_line(ts: f64) -> String {
+    format!(
+        "{{\"type\":\"user\",\"timestamp\":\"{}\",\
+         \"message\":{{\"role\":\"user\",\"content\":\"hi\"}}}}\n",
+        iso(ts)
+    )
+}
+
+fn assistant_line(ts: f64) -> String {
+    format!(
+        concat!(
+            r#"{{"type":"assistant","timestamp":"{}","message":{{"role":"assistant","#,
+            r#""model":"claude-sonnet-5","content":[{{"type":"text","text":"hello"}}],"#,
+            r#""usage":{{"input_tokens":5,"output_tokens":5}}}},"costUSD":0.01}}"#,
+            "\n",
+        ),
+        iso(ts)
+    )
+}
+
+fn iso(ts: f64) -> String {
+    DateTime::from_timestamp(ts as i64, 0)
+        .expect("valid timestamp")
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string()
+}
+
+fn wall_clock_now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("clock after the epoch")
+        .as_secs_f64()
+}
+
+/// Spawns `hermon agent --interval 1` against a claude fixture and
+/// nonexistent hermes/opencode stores (both degrade to "no sessions", same
+/// as every other source-reading command), piping both stdin and stdout.
+fn spawn_agent(claude: &TempDir) -> std::process::Child {
+    Proc::new(env!("CARGO_BIN_EXE_hermon"))
+        .arg("agent")
+        .arg("--interval")
+        .arg("1")
+        .arg("--claude-dir")
+        .arg(claude.path())
+        .arg("--hermes-db")
+        .arg("/nonexistent/state.db")
+        .arg("--opencode-db")
+        .arg("/nonexistent/opencode.db")
+        .arg("--hermes-log")
+        .arg("/nonexistent/agent.log")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn hermon agent")
+}
+
+/// Reads stdout lines on a background thread into a channel, so the test
+/// can interleave writing to stdin without either direction deadlocking.
+fn spawn_line_reader(stdout: std::process::ChildStdout) -> mpsc::Receiver<String> {
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        let mut reader = BufReader::new(stdout);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    if tx.send(line.trim_end().to_string()).is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+    rx
+}
+
+#[test]
+fn agent_streams_hello_snap_tail_and_exits_promptly_on_stdin_eof() {
+    let claude = claude_dir();
+    let mut child = spawn_agent(&claude);
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    let lines = spawn_line_reader(child.stdout.take().expect("piped stdout"));
+
+    // Hello arrives immediately, naming all three sources.
+    let hello = lines
+        .recv_timeout(Duration::from_secs(2))
+        .expect("Hello frame");
+    match decode_agent_msg(&hello) {
+        Decoded::Msg(AgentMsg::Hello { sources, .. }) => {
+            assert_eq!(sources, vec!["claude", "hermes", "opencode"]);
+        }
+        other => panic!("expected Hello, got {other:?}"),
+    }
+
+    // A Snap follows within the 1s interval and names the fixture session.
+    let key = (0..5)
+        .find_map(|_| {
+            let line = lines.recv_timeout(Duration::from_secs(2)).ok()?;
+            match decode_agent_msg(&line) {
+                Decoded::Msg(AgentMsg::Snap { sessions }) => {
+                    sessions.iter().find(|s| s.id.starts_with("C:")).cloned()
+                }
+                _ => None,
+            }
+        })
+        .expect("Snap named the fixture claude session")
+        .id;
+
+    // Ask the agent to tail it; the replayed lines come back as a Tail frame.
+    let open = encode_host_cmd(&HostCmd::OpenTail {
+        key: key.clone(),
+        replay: Replay::DEFAULT,
+    });
+    writeln!(stdin, "{open}").expect("write OpenTail");
+    stdin.flush().expect("flush OpenTail");
+
+    let saw_tail = (0..10).any(|_| {
+        let Ok(line) = lines.recv_timeout(Duration::from_secs(2)) else {
+            return false;
+        };
+        matches!(
+            decode_agent_msg(&line),
+            Decoded::Msg(AgentMsg::Tail { key: ref k, ref lines }) if *k == key && !lines.is_empty()
+        )
+    });
+    assert!(saw_tail, "expected a Tail frame after OpenTail");
+
+    // Closing stdin (EOF) exits the process within one interval.
+    drop(stdin);
+    let (exit_tx, exit_rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = exit_tx.send(child.wait());
+    });
+    let status = exit_rx
+        .recv_timeout(Duration::from_secs(3))
+        .expect("hermon agent exits promptly on stdin EOF")
+        .expect("wait on child");
+    assert!(status.success(), "{status:?}");
+}
+
+#[test]
+fn agent_stdout_carries_only_frames() {
+    let claude = claude_dir();
+    let mut child = spawn_agent(&claude);
+    let stdin = child.stdin.take().expect("piped stdin");
+    let mut reader = BufReader::new(child.stdout.take().expect("piped stdout"));
+
+    let mut seen = Vec::new();
+    let mut line = String::new();
+    let deadline = Instant::now() + Duration::from_millis(1500);
+    while Instant::now() < deadline {
+        line.clear();
+        match reader.read_line(&mut line) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => seen.push(line.trim_end().to_string()),
+        }
+    }
+    drop(stdin);
+    let _ = child.wait();
+
+    assert!(!seen.is_empty(), "expected at least Hello + Snap");
+    for line in &seen {
+        assert!(
+            matches!(decode_agent_msg(line), Decoded::Msg(_)),
+            "non-frame bytes on stdout: {line:?}"
+        );
+    }
+}


### PR DESCRIPTION
########## ISSUE #89 ##########
hermon agent: in-container streamer over stdio
Blocked by #88 (protocol).
MODEL: sonnet5 — mostly reuse of existing sources behind a loop, but the stdin thread, EOF-exit, and never-block-on-a-stalled-pipe backpressure rules are the kind of plumbing that goes subtly wrong; worth the mid tier.

**In plain terms:** The half that runs inside the container: `hermon agent` reads that machine's session stores and streams what it sees to stdout.

---

**Why**
Inside the container, the existing sources just work — the stores are local files again, and even lsof liveness works (the writing processes are visible in the same namespace). The agent is deliberately dumb: read stores, print frames, obey stdin.

**What to build**
Repo specifics: add an `Agent` variant to the clap `Subcommand` enum in `cli.rs` sharing `SourceArgs` (claude-dir, hermes-db, opencode-db, hermes-log — same as Watch/Ls/Gui), plus `--interval`; one dispatch arm in main.rs. Reuse the `roster.rs` `Sources` registry and its `open_tailer` (key-prefix dispatch "C"/"H"/"O") — do not build a parallel source path. Frames are #88's `AgentMsg`/`HostCmd` via the pure proto helpers in `src/remote/proto.rs`; agent loop lives in `src/remote/agent.rs`.
- `agent` subcommand: emits `Hello` immediately (with `PROTO_VERSION`, hostname, active source names), then a `Snap` every `--interval` (full snapshot, not diffs — the host diffs, and snapshots make reconnection trivial).
- stdin loop (own thread): `OpenTail` opens the real tailer via the existing `open_tailer` and its lines flow as `Tail` frames on the fast tick; `CloseTail` drops it; `Shutdown` (or stdin EOF — the transport died) exits promptly. EOF-exit matters: an orphaned agent in a container must not linger.
- Notifications, TUI, lsof warnings etc. all OFF in agent mode — it's a pipe, not a UI; stderr carries diagnostics, stdout carries ONLY frames.
- Unbuffered/line-flushed stdout (a blocked pipe must not wedge the scan loop — if the reader stalls, prefer dropping Tail frames over blocking; Snap must always get through).
- Static-friendly: the binary users copy into containers is the same `hermon`; no separate build.
- Malformed stdin lines → `ParseSkip` per #88, log one dim stderr diagnostic, keep running — never exit on garbage.

Seam note: builds only on #88's proto (merged). #90 will spawn this exact subcommand as its test child (`cmd:`-style transport, no docker) — the fifo pipe test below is the shape #90's e2e reuses, so keep the agent runnable against the existing fixture stores in `tests/`.

**Out of scope**
The host side. Transport spawning. musl/cross-compile builds (packaging ticket #93).

**Acceptance criteria**
- Pipe test, no docker needed: `hermon agent --interval 1 < cmds.fifo | head` against fixture stores emits Hello then Snaps; writing an OpenTail into the fifo yields Tail frames; closing stdin exits within one interval (assert with `timeout`).
- stdout contains zero non-frame bytes across a full session (grep for anything that fails to parse).
- `cargo test` + CI green (clippy -D warnings, fmt).