### PR TITLE
remote: docker auto-discovery via container labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,57 @@ Each store path is overridable per subcommand: `--claude-dir`, `--hermes-db`,
 `--opencode-db`, `--hermes-log`. Both SQLite stores are opened read-only
 (`file:…?mode=ro`), safe alongside the real tool running (WAL).
 
+## Remote agents (containers, hosts)
+
+`hermon watch`/`gui`/`menubar` can also follow sessions running inside a
+container or on another host over `hermon agent`, a small stdio-piped mode
+that streams the same three sources' sessions out. Each remote's sessions
+show up under a `name/` roster prefix (`job1/C:0f865f`), tailed live like
+any local session.
+
+Two ways to attach one:
+
+- **`--remote docker:<container>[:name]`** / **`--remote ssh:<host>[:name]`**
+  (repeatable) — explicit, one flag per remote, resolved once at startup.
+  `ssh:` uses key-based auth only (`BatchMode=yes`, no password fallback).
+  `--remote cmd:<argv…>` is an escape hatch for podman, `kubectl exec`, or
+  anything else. `--remote-flags "..."` forwards extra flags (e.g.
+  `--claude-dir /work/.claude`) to every remote's own `hermon agent`
+  invocation. This is the **paranoid mode**: nothing is followed that you
+  didn't name yourself.
+- **`--docker-auto`** — follow every currently-running container labeled
+  `dev.hermon.agent`, polled alongside the roster scan (no separate timer).
+  A container's own name is the roster prefix, unless it also carries a
+  `dev.hermon.agent.name` label to override it. Containers are picked up
+  and torn down automatically as they start and stop; an explicit
+  `--remote` with the same name always wins a collision.
+
+  ```bash
+  docker run -d --label dev.hermon.agent=1 --label dev.hermon.agent.name=worker1 my-image
+  ```
+
+  A Dockerfile only needs the `hermon` binary on `PATH`:
+
+  ```dockerfile
+  FROM my-base-image
+  COPY --from=ghcr.io/drazthan/hermon:latest /usr/local/bin/hermon /usr/local/bin/hermon
+  LABEL dev.hermon.agent=1
+  ```
+
+  **`--docker-auto` extends monitoring trust to every labeled image you
+  run.** A container's labels come from its image, not from you — running
+  any third-party image with `LABEL dev.hermon.agent` set gets it
+  auto-followed with no action on your part, the same as any other trust
+  decision you make by running an image at all. Container names and the
+  `dev.hermon.agent.name` label are validated the same way an explicit
+  `--remote docker:` spec's container name is (rejecting a leading `-` or
+  an unexpected character before it can reach `docker exec`'s argv), the
+  label is sanitized and length-capped before it becomes a roster prefix,
+  and a collision with an explicit `--remote` is refused and logged rather
+  than silently followed. None of that changes the underlying trade-off:
+  if you don't want to extend that trust to everything you run, use
+  explicit `--remote docker:<name>` instead.
+
 ## Install
 
 Two things live in the tap: a formula for the CLI (`hermon watch`/`ls`/
@@ -317,6 +368,9 @@ Defaults make `hermon watch` correct with zero flags.
 | `--replay-bytes` | `20480` | history a freshly opened pane replays from a file-backed source (Claude) |
 | `--replay-lines` | `40` | history a freshly opened pane replays from a DB-backed source (Hermes, OpenCode) |
 | `--fresh-window` (`ls`, `render` only) | `3600` | roster lookback for recently-finished sessions; `watch` isn't given this flag and keeps the tighter 300s inherited default |
+| `--remote` | none | attach a remote agent, repeatable; see [Remote agents](#remote-agents-containers-hosts) |
+| `--remote-flags` | none | extra flags forwarded to every `--remote docker:`/`ssh:` remote's own `hermon agent` |
+| `--docker-auto` | off | follow every container labeled `dev.hermon.agent` automatically; see [Remote agents](#remote-agents-containers-hosts) |
 
 `hermon ls` and `hermon render` honor `NO_COLOR` (and fall back to plain text
 automatically when stdout isn't a terminal); the ratatui screen (`hermon

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,6 +178,21 @@ pub struct SourceArgs {
     /// already complete.
     #[arg(long, default_value = "")]
     pub remote_flags: String,
+
+    /// Follow every container labeled `dev.hermon.agent` automatically
+    /// (#92): polled alongside the roster scan, no separate timer. A
+    /// container's own name is the roster prefix unless it also carries a
+    /// `dev.hermon.agent.name` label; either way the name is validated the
+    /// same way a `--remote docker:` spec's container name is. An explicit
+    /// `--remote` with the same name always wins. **This extends
+    /// monitoring trust to every labeled image you run** — an image's own
+    /// `LABEL dev.hermon.agent` gets it auto-followed with no action from
+    /// you, so treat it like running the image at all: fine for your own
+    /// containers, not for arbitrary third-party ones. Use explicit
+    /// `--remote docker:<name>` instead if that's not a trade-off you
+    /// want to make.
+    #[arg(long)]
+    pub docker_auto: bool,
 }
 
 impl SourceArgs {

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,4 +43,8 @@ pub struct EngineConfig {
     /// `--remote-flags`, already split, forwarded verbatim to every
     /// `docker:`/`ssh:` remote's own `hermon agent` invocation.
     pub remote_flags: Vec<String>,
+    /// `--docker-auto` (#92): poll `docker ps` on every scan tick and
+    /// follow any container labeled `dev.hermon.agent`, alongside whatever
+    /// `remotes` already lists explicitly.
+    pub docker_auto: bool,
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -25,8 +25,9 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::config::EngineConfig;
 use crate::notify::{self, Alert, AlertHistory, DoneCause, LifecycleTransition, Notifier};
+use crate::remote::discover::{self, Discovered};
 use crate::remote::source::RemoteSource;
-use crate::remote::spec::to_command;
+use crate::remote::spec::{docker_spec, to_command};
 use crate::render::{Sem, StyledLine};
 use crate::roster::{RosterRow, Sources, TICKER_LIMIT, api_call_ticker, build_roster};
 use crate::source::{Attn, Liveness, Replay, Tailer};
@@ -131,6 +132,19 @@ pub trait Deck {
         session_id: &str,
         replay: Replay,
     ) -> Option<Box<dyn Tailer>>;
+
+    /// Applies one `--docker-auto` discovery tick's decisions: spawns each
+    /// newly (or re-)discovered container's remote, tears down each one
+    /// that disappeared. Default no-op — only [`Sources`], the production
+    /// deck, has remotes to manage; the engine's test fakes never enable
+    /// `--docker-auto`, so they never need an override.
+    fn sync_docker_auto(
+        &mut self,
+        _spawn: Vec<Discovered>,
+        _remove: Vec<String>,
+        _remote_flags: &[String],
+    ) {
+    }
 }
 
 impl Deck for Sources {
@@ -145,6 +159,22 @@ impl Deck for Sources {
         replay: Replay,
     ) -> Option<Box<dyn Tailer>> {
         Sources::open_tailer(self, key, session_id, replay)
+    }
+
+    fn sync_docker_auto(
+        &mut self,
+        spawn: Vec<Discovered>,
+        remove: Vec<String>,
+        remote_flags: &[String],
+    ) {
+        for name in remove {
+            self.remove_remote(&name);
+        }
+        for d in spawn {
+            let spec = docker_spec(d.container, d.name);
+            let cmd = to_command(&spec, remote_flags);
+            self.add_remote(RemoteSource::new(spec.name.clone(), cmd));
+        }
     }
 }
 
@@ -176,6 +206,76 @@ struct Tracked {
     /// re-entry, and on switching from one attention reason to the other,
     /// so elapsed-in-state always measures the *current* reason.
     attn_since: Option<f64>,
+}
+
+/// Cross-tick bookkeeping for `--docker-auto`, threaded through [`run`]'s
+/// loop the same way `tracked`/`ids` are: which containers are currently
+/// spawned (by container id, to the name they're running under, so a
+/// rename can be told apart from a plain disappear-then-reappear), whether
+/// `docker` has already proven unusable this run, and which warnings have
+/// already been printed once so a standing collision doesn't spam stderr
+/// every tick.
+#[derive(Debug, Default)]
+struct DockerAutoState {
+    managed: HashMap<String, String>,
+    disabled: bool,
+    warned: HashSet<String>,
+}
+
+/// Runs `docker ps --filter label=<AGENT_LABEL> --format {{json .}}` for
+/// one discovery tick. `Err` names why it failed — `docker` missing from
+/// `PATH`, or a nonzero exit (daemon unreachable, say) — so the caller can
+/// warn once and turn the feature off rather than retrying a broken
+/// `docker` every tick forever.
+fn run_docker_ps() -> Result<String, String> {
+    let output = std::process::Command::new("docker")
+        .args([
+            "ps",
+            "--filter",
+            &format!("label={}", discover::AGENT_LABEL),
+            "--format",
+            "{{json .}}",
+        ])
+        .output()
+        .map_err(|e| format!("docker ps: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "docker ps: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// One `--docker-auto` discovery tick: runs `docker ps`, reconciles it
+/// against last tick's bookkeeping, and applies the result to `deck`. A
+/// no-op once `docker` has proven unusable ([`DockerAutoState::disabled`])
+/// — the "bounded" half of the issue's "poll, bounded; docker absent -> one
+/// warning, feature off".
+fn sync_docker_auto(config: &EngineConfig, deck: &mut dyn Deck, state: &mut DockerAutoState) {
+    if !config.docker_auto || state.disabled {
+        return;
+    }
+    let stdout = match run_docker_ps() {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("hermon: --docker-auto: {e}, disabling for this run");
+            state.disabled = true;
+            return;
+        }
+    };
+    let containers = discover::parse_ps(&stdout);
+    let explicit: HashSet<String> = config.remotes.iter().map(|r| r.name.clone()).collect();
+    let (sync, next) = discover::reconcile(&containers, &explicit, &state.managed);
+    for warning in &sync.warnings {
+        if state.warned.insert(warning.clone()) {
+            eprintln!("hermon: {warning}");
+        }
+    }
+    state.managed = next;
+    if !sync.spawn.is_empty() || !sync.remove.is_empty() {
+        deck.sync_docker_auto(sync.spawn, sync.remove, &config.remote_flags);
+    }
 }
 
 pub struct Engine;
@@ -254,6 +354,8 @@ fn run(
     // Keys the UI has pinned, replaced wholesale on every `UiCmd::Pinned`.
     // Eviction never picks a victim from this set (#42).
     let mut pinned: HashSet<String> = HashSet::new();
+    // `--docker-auto` (#92) bookkeeping; a no-op tick when the flag is off.
+    let mut docker_auto = DockerAutoState::default();
 
     let mut next_scan = Instant::now();
     let mut next_pane_tick = Instant::now();
@@ -273,6 +375,7 @@ fn run(
                 &mut hist,
                 &notifier,
                 &pinned,
+                &mut docker_auto,
             )
             .is_err()
             {
@@ -356,7 +459,9 @@ fn scan(
     hist: &mut AlertHistory,
     notifier: &Notifier,
     pinned: &HashSet<String>,
+    docker_auto: &mut DockerAutoState,
 ) -> Result<(), ()> {
+    sync_docker_auto(config, deck, docker_auto);
     let now = clock();
     let mut rows = deck.roster(now, config.fresh_window, config.idle_timeout);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@ pub fn run() -> anyhow::Result<()> {
                 replay,
                 remotes,
                 remote_flags,
+                docker_auto: args.docker_auto,
             };
             ui::run_tui(config)
         }
@@ -139,6 +140,7 @@ pub fn run() -> anyhow::Result<()> {
                 replay,
                 remotes,
                 remote_flags,
+                docker_auto: args.docker_auto,
             };
             gui::run_gui(config)
         }
@@ -188,6 +190,7 @@ pub fn run() -> anyhow::Result<()> {
                 replay,
                 remotes,
                 remote_flags,
+                docker_auto: args.source.docker_auto,
             };
             menubar::run(config)
         }

--- a/src/remote/discover.rs
+++ b/src/remote/discover.rs
@@ -1,0 +1,457 @@
+//! Docker auto-discovery (#92): pure functions over `docker ps` JSON that
+//! decide which labeled containers should become remotes, and which
+//! previously-discovered ones should be torn down. Nothing here spawns or
+//! execs anything — [`crate::engine`]'s scan tick is the only caller, and
+//! it is the one place that actually runs `docker ps` and turns
+//! [`Discovered`] into a running [`crate::remote::source::RemoteSource`]
+//! via [`crate::remote::spec::docker_spec`] and
+//! [`crate::remote::spec::to_command`].
+//!
+//! **Provenance invariant, sanctioned exception** (see the invariant
+//! documented at the top of [`crate::remote::spec`]): every name handled
+//! here — a container's own name and its optional `dev.hermon.agent.name`
+//! label — comes from `docker ps`, i.e. from whatever happens to be
+//! running on this machine, not from the user's own `--docker-auto`
+//! invocation. #91's provenance invariant forbids exactly that for
+//! `--remote`; #92 is the one place allowed to break it, on three
+//! conditions kept together here rather than scattered across the crate:
+//!
+//! 1. every name — container name *and* label value — is validated with
+//!    [`crate::remote::spec::validate_name`] before it can reach argv (a
+//!    hostile image could otherwise name its own container `-oProxyCommand=…`
+//!    the same way an `ssh:`/`docker:` `--remote` spec could);
+//! 2. the label value is additionally sanitized ([`crate::render::sanitize`])
+//!    and length-capped before it becomes a roster prefix, since unlike a
+//!    container name (docker's own charset is already stricter than ours)
+//!    it is free-form display text a hostile image fully controls;
+//! 3. an explicit `--remote` always wins a name collision — a colliding
+//!    label is exactly what a hostile image would carry to get
+//!    auto-followed (label spoofing, threat review 2026-08-31), so the
+//!    collision is refused and logged visibly rather than silently
+//!    resolved.
+//!
+//! `--docker-auto` itself is a trust extension, not a bug: running any
+//! third-party image with the label at all opts every container it starts
+//! into being followed. See the README's `--docker-auto` section for the
+//! plain statement of that trade-off.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::remote::spec::validate_name;
+use crate::render::{clip, sanitize};
+
+/// The label that opts a container into `--docker-auto` at all. Passed
+/// bare to `docker ps --filter label=…`, so any value (or none) counts —
+/// only [`AGENT_NAME_LABEL`] carries meaning.
+pub const AGENT_LABEL: &str = "dev.hermon.agent";
+
+/// The label whose value overrides the roster name a container's own
+/// `docker ps` name would otherwise give it.
+pub const AGENT_NAME_LABEL: &str = "dev.hermon.agent.name";
+
+/// Longest a `dev.hermon.agent.name` label may be once sanitized. It
+/// becomes a roster prefix, not a bounded protocol field like #90's wire
+/// frames, so a hostile image could otherwise hand us an arbitrarily long
+/// string to spam the roster with.
+const MAX_LABEL_NAME_LEN: usize = 64;
+
+/// One row of `docker ps --format {{json .}}` output, the fields this
+/// module reads. `#[serde(default)]` on every field: a `docker ps` build
+/// that omits one is a missing value here, not a parse failure.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+struct PsEntry {
+    #[serde(rename = "ID", default)]
+    id: String,
+    #[serde(rename = "Names", default)]
+    names: String,
+    #[serde(rename = "Labels", default)]
+    labels: String,
+}
+
+/// One running, labeled container as `docker ps` reported it, before any
+/// validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Container {
+    /// Docker's own container id — the stable identity a name change (a
+    /// `docker rename`, or an edited `dev.hermon.agent.name` label) is
+    /// tracked against across ticks.
+    pub id: String,
+    /// The container name `docker exec` targets.
+    pub name: String,
+    /// The raw `dev.hermon.agent.name` label value, if the container set
+    /// one — not yet validated or sanitized.
+    pub agent_name: Option<String>,
+}
+
+/// Parses `docker ps --format {{json .}}` output: one JSON object per
+/// line (docker's own format — not a JSON array), kept only when its
+/// `Labels` field actually carries [`AGENT_LABEL`]. `docker ps --filter
+/// label=…` already does this filtering server-side; re-checking it here
+/// means an unlabeled container can never appear even if the filter is
+/// ever dropped or misapplied by a caller.
+///
+/// A line that fails to parse, or names no container id, is skipped, not
+/// fatal — a future `docker ps` field change must not take discovery down.
+pub fn parse_ps(stdout: &str) -> Vec<Container> {
+    stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|line| serde_json::from_str::<PsEntry>(line).ok())
+        .filter(|e| !e.id.is_empty() && has_label(&e.labels, AGENT_LABEL))
+        .map(|e| Container {
+            id: e.id,
+            // A container normally has exactly one name; docker joins
+            // several with commas in the rare cases it has more. The
+            // first is as good a choice as any and keeps a single
+            // `validate_name`-clean token.
+            name: e.names.split(',').next().unwrap_or_default().to_string(),
+            agent_name: label_value(&e.labels, AGENT_NAME_LABEL),
+        })
+        .collect()
+}
+
+/// Whether `docker ps`'s comma-joined `key=value,…` `Labels` field carries
+/// `key` at all (with any value, or none).
+fn has_label(labels: &str, key: &str) -> bool {
+    labels
+        .split(',')
+        .any(|kv| kv.split('=').next() == Some(key))
+}
+
+/// Reads one label's value out of the same `Labels` field. Docker doesn't
+/// escape a comma inside a label value in this format, so a value
+/// containing one would be split wrong here — a pre-existing `docker ps`
+/// limitation, not something this module works around.
+fn label_value(labels: &str, key: &str) -> Option<String> {
+    labels
+        .split(',')
+        .find_map(|kv| kv.split_once('=').filter(|(k, _)| *k == key))
+        .map(|(_, v)| v.to_string())
+}
+
+/// One container cleared to become (or stay) a remote: both names already
+/// validated, the display name sanitized and length-capped, ready for
+/// [`crate::remote::spec::docker_spec`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Discovered {
+    pub id: String,
+    /// The container name docker itself uses.
+    pub container: String,
+    /// The roster prefix this remote's keys will carry.
+    pub name: String,
+}
+
+/// What one discovery tick decided: remotes to start, remotes (by name) to
+/// tear down, and anything worth a visible log line — an invalid name, or
+/// a collision with an explicit `--remote`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Sync {
+    pub spawn: Vec<Discovered>,
+    pub remove: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+/// Reconciles this tick's `docker ps` listing against what was running
+/// last tick — pure: no docker, no clock, nothing spawned. `managed` is
+/// the caller's own bookkeeping from the previous tick (container id ->
+/// the name it's running under); `explicit` is every name already taken
+/// by a `--remote` flag, which always wins a collision. Returns this
+/// tick's decisions plus the bookkeeping to pass back in next tick.
+///
+/// Rename handling: if a still-present container's computed name changes
+/// (its own name changed, or its label did), the old name is torn down
+/// and the container respawns under the new one — a running
+/// [`crate::remote::source::RemoteSource`] has no rename operation, so
+/// this is the only way to change what a container's keys are prefixed
+/// with.
+pub fn reconcile(
+    containers: &[Container],
+    explicit: &HashSet<String>,
+    managed: &HashMap<String, String>,
+) -> (Sync, HashMap<String, String>) {
+    let mut sync = Sync::default();
+    let mut next: HashMap<String, String> = HashMap::new();
+    // Names claimed by a container already processed this tick, so two
+    // containers racing for the same label don't both spawn.
+    let mut claimed: HashSet<String> = HashSet::new();
+
+    for c in containers {
+        if let Err(e) = validate_name(&c.name) {
+            sync.warnings.push(format!(
+                "docker-auto: container {} has an invalid name {:?} ({e}), skipping",
+                c.id, c.name
+            ));
+            continue;
+        }
+
+        let name = match &c.agent_name {
+            Some(raw) => match validate_name(raw) {
+                Ok(()) => clip(&sanitize(raw), MAX_LABEL_NAME_LEN),
+                Err(e) => {
+                    sync.warnings.push(format!(
+                        "docker-auto: container {:?} has an invalid {AGENT_NAME_LABEL} label \
+                         {raw:?} ({e}), falling back to the container name",
+                        c.name
+                    ));
+                    c.name.clone()
+                }
+            },
+            None => c.name.clone(),
+        };
+
+        if explicit.contains(&name) {
+            sync.warnings.push(format!(
+                "docker-auto: container {:?} labeled name {name:?} collides with an explicit \
+                 --remote, ignoring (possible label spoofing)",
+                c.name
+            ));
+            continue;
+        }
+        if !claimed.insert(name.clone()) {
+            sync.warnings.push(format!(
+                "docker-auto: container {:?} labeled name {name:?} collides with another \
+                 discovered container this tick, ignoring",
+                c.name
+            ));
+            continue;
+        }
+
+        if managed.get(&c.id) != Some(&name) {
+            if let Some(old) = managed.get(&c.id) {
+                sync.remove.push(old.clone());
+            }
+            sync.spawn.push(Discovered {
+                id: c.id.clone(),
+                container: c.name.clone(),
+                name: name.clone(),
+            });
+        }
+        next.insert(c.id.clone(), name);
+    }
+
+    for (id, name) in managed {
+        if !next.contains_key(id) {
+            sync.remove.push(name.clone());
+        }
+    }
+
+    (sync, next)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ps_line(id: &str, name: &str, labels: &str) -> String {
+        format!(
+            r#"{{"ID":"{id}","Names":"{name}","Labels":"{labels}","Image":"x","State":"running"}}"#
+        )
+    }
+
+    // -------------------------------------------------------------- parse_ps
+
+    #[test]
+    fn parse_ps_reads_labeled_containers() {
+        let stdout = ps_line("abc123", "job1", "dev.hermon.agent=1");
+        let containers = parse_ps(&stdout);
+        assert_eq!(containers.len(), 1);
+        assert_eq!(containers[0].id, "abc123");
+        assert_eq!(containers[0].name, "job1");
+        assert_eq!(containers[0].agent_name, None);
+    }
+
+    #[test]
+    fn parse_ps_reads_the_agent_name_label() {
+        let stdout = ps_line(
+            "abc123",
+            "job1",
+            "dev.hermon.agent=1,dev.hermon.agent.name=worker1",
+        );
+        let containers = parse_ps(&stdout);
+        assert_eq!(containers[0].agent_name, Some("worker1".to_string()));
+    }
+
+    #[test]
+    fn parse_ps_never_returns_an_unlabeled_container() {
+        let stdout = ps_line("abc123", "job1", "some.other.label=1");
+        assert!(parse_ps(&stdout).is_empty());
+    }
+
+    #[test]
+    fn parse_ps_skips_malformed_lines_without_failing_the_rest() {
+        let stdout = format!(
+            "not json at all\n{}\n",
+            ps_line("abc123", "job1", "dev.hermon.agent=1")
+        );
+        let containers = parse_ps(&stdout);
+        assert_eq!(containers.len(), 1);
+        assert_eq!(containers[0].id, "abc123");
+    }
+
+    #[test]
+    fn parse_ps_skips_entries_missing_an_id() {
+        let stdout = ps_line("", "job1", "dev.hermon.agent=1");
+        assert!(parse_ps(&stdout).is_empty());
+    }
+
+    #[test]
+    fn parse_ps_reads_multiple_lines() {
+        let stdout = format!(
+            "{}\n{}\n",
+            ps_line("id1", "job1", "dev.hermon.agent=1"),
+            ps_line("id2", "job2", "dev.hermon.agent=1")
+        );
+        let containers = parse_ps(&stdout);
+        assert_eq!(containers.len(), 2);
+    }
+
+    // -------------------------------------------------------------- reconcile
+
+    fn container(id: &str, name: &str, agent_name: Option<&str>) -> Container {
+        Container {
+            id: id.to_string(),
+            name: name.to_string(),
+            agent_name: agent_name.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn a_new_container_is_spawned() {
+        let containers = vec![container("id1", "job1", None)];
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert_eq!(
+            sync.spawn,
+            vec![Discovered {
+                id: "id1".to_string(),
+                container: "job1".to_string(),
+                name: "job1".to_string(),
+            }]
+        );
+        assert!(sync.remove.is_empty());
+        assert_eq!(next.get("id1"), Some(&"job1".to_string()));
+    }
+
+    #[test]
+    fn a_container_gone_from_docker_ps_is_removed() {
+        let managed = HashMap::from([("id1".to_string(), "job1".to_string())]);
+        let (sync, next) = reconcile(&[], &HashSet::new(), &managed);
+        assert_eq!(sync.remove, vec!["job1".to_string()]);
+        assert!(sync.spawn.is_empty());
+        assert!(next.is_empty());
+    }
+
+    #[test]
+    fn an_unchanged_container_neither_spawns_nor_removes() {
+        let containers = vec![container("id1", "job1", None)];
+        let managed = HashMap::from([("id1".to_string(), "job1".to_string())]);
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &managed);
+        assert!(sync.spawn.is_empty());
+        assert!(sync.remove.is_empty());
+        assert_eq!(next.get("id1"), Some(&"job1".to_string()));
+    }
+
+    #[test]
+    fn a_renamed_container_tears_down_the_old_name_and_spawns_the_new_one() {
+        // Same container id, its dev.hermon.agent.name label changed.
+        let containers = vec![container("id1", "job1", Some("worker2"))];
+        let managed = HashMap::from([("id1".to_string(), "worker1".to_string())]);
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &managed);
+        assert_eq!(sync.remove, vec!["worker1".to_string()]);
+        assert_eq!(
+            sync.spawn,
+            vec![Discovered {
+                id: "id1".to_string(),
+                container: "job1".to_string(),
+                name: "worker2".to_string(),
+            }]
+        );
+        assert_eq!(next.get("id1"), Some(&"worker2".to_string()));
+    }
+
+    #[test]
+    fn a_name_colliding_with_an_explicit_remote_is_refused_and_logged() {
+        let containers = vec![container("id1", "job1", None)];
+        let explicit = HashSet::from(["job1".to_string()]);
+        let (sync, next) = reconcile(&containers, &explicit, &HashMap::new());
+        assert!(sync.spawn.is_empty(), "explicit --remote wins");
+        assert!(next.is_empty());
+        assert!(
+            sync.warnings.iter().any(|w| w.contains("collides")),
+            "{:?}",
+            sync.warnings
+        );
+    }
+
+    #[test]
+    fn a_container_that_becomes_a_collision_after_a_rename_is_torn_down() {
+        // job1 was legitimately auto-discovered as "worker1"; its label
+        // then changes to collide with an explicit --remote named "job1".
+        let containers = vec![container("id1", "job1", Some("job1"))];
+        let explicit = HashSet::from(["job1".to_string()]);
+        let managed = HashMap::from([("id1".to_string(), "worker1".to_string())]);
+        let (sync, next) = reconcile(&containers, &explicit, &managed);
+        assert_eq!(sync.remove, vec!["worker1".to_string()]);
+        assert!(sync.spawn.is_empty());
+        assert!(!next.contains_key("id1"));
+    }
+
+    #[test]
+    fn two_containers_racing_for_the_same_label_only_spawn_the_first() {
+        let containers = vec![
+            container("id1", "job1", Some("worker")),
+            container("id2", "job2", Some("worker")),
+        ];
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert_eq!(sync.spawn.len(), 1);
+        assert_eq!(sync.spawn[0].id, "id1");
+        assert_eq!(next.len(), 1);
+        assert!(
+            sync.warnings.iter().any(|w| w.contains("collides")),
+            "{:?}",
+            sync.warnings
+        );
+    }
+
+    #[test]
+    fn an_invalid_container_name_is_skipped_and_logged() {
+        let containers = vec![container("id1", "-oProxyCommand=evil", None)];
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert!(sync.spawn.is_empty());
+        assert!(next.is_empty());
+        assert!(
+            sync.warnings.iter().any(|w| w.contains("invalid name")),
+            "{:?}",
+            sync.warnings
+        );
+    }
+
+    #[test]
+    fn an_invalid_label_falls_back_to_the_container_name() {
+        let containers = vec![container("id1", "job1", Some("bad name; rm -rf"))];
+        let (sync, _next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert_eq!(sync.spawn[0].name, "job1");
+        assert!(
+            sync.warnings
+                .iter()
+                .any(|w| w.contains("falling back to the container name")),
+            "{:?}",
+            sync.warnings
+        );
+    }
+
+    #[test]
+    fn a_hostile_label_is_sanitized_and_length_capped() {
+        let hostile = "x\x1b[31m".repeat(20); // control bytes, well over the cap
+        let containers = vec![container("id1", "job1", Some(&hostile))];
+        // Control bytes fail validate_name's charset check, so this falls
+        // back to the container name — the cap/sanitize path is exercised
+        // by a long but charset-clean label instead.
+        let (sync, _next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert_eq!(sync.spawn[0].name, "job1");
+
+        let long_clean = "a".repeat(200);
+        let containers = vec![container("id2", "job2", Some(&long_clean))];
+        let (sync, _next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert_eq!(sync.spawn[0].name.chars().count(), MAX_LABEL_NAME_LEN);
+    }
+}

--- a/src/remote/mod.rs
+++ b/src/remote/mod.rs
@@ -3,10 +3,12 @@
 //! See [`proto`] for the wire format both halves share, [`agent`] for the
 //! in-container half that streams frames, [`source`] for the host half that
 //! spawns a transport, demuxes those frames, and presents the remote as one
-//! more [`crate::source::Source`], and [`spec`] for turning a user's
-//! `--remote` flag into the `Command` `source` spawns.
+//! more [`crate::source::Source`], [`spec`] for turning a user's `--remote`
+//! flag into the `Command` `source` spawns, and [`discover`] for
+//! `--docker-auto`'s label-driven discovery of the same.
 
 pub mod agent;
+pub mod discover;
 pub mod proto;
 pub mod source;
 pub mod spec;

--- a/src/remote/spec.rs
+++ b/src/remote/spec.rs
@@ -228,6 +228,21 @@ pub fn split_argv(s: &str) -> Result<Vec<String>, SpecError> {
     Ok(words)
 }
 
+/// Builds a `docker:` [`RemoteSpec`] directly from an already-validated
+/// container name and display name — the constructor #92's `--docker-auto`
+/// discovery uses instead of building a spec string and feeding
+/// docker-influenced data back through [`parse_spec`], per the provenance
+/// invariant above. Callers must run [`validate_name`] on both `container`
+/// and `name` themselves first; this does not re-validate either.
+pub fn docker_spec(container: impl Into<String>, name: impl Into<String>) -> RemoteSpec {
+    RemoteSpec {
+        name: name.into(),
+        kind: Kind::Docker {
+            container: container.into(),
+        },
+    }
+}
+
 /// Builds the `Command` [`RemoteSource::new`] spawns and supervises for
 /// this spec — the only place in this module that constructs a `Command`,
 /// and it does not spawn one. `agent_flags` (`--remote-flags`, already
@@ -468,6 +483,15 @@ mod tests {
     }
 
     // ------------------------------------------------------------- misc
+
+    #[test]
+    fn docker_spec_builds_a_docker_kind_spec_without_string_parsing() {
+        let spec = docker_spec("job1", "worker");
+        assert_eq!(spec.name, "worker");
+        let cmd = to_command(&spec, &[]);
+        assert_eq!(cmd.get_program().to_string_lossy(), "docker");
+        assert_eq!(args_of(&cmd), vec!["exec", "-i", "job1", "hermon", "agent"]);
+    }
 
     #[test]
     fn an_unknown_transport_is_rejected() {

--- a/src/roster.rs
+++ b/src/roster.rs
@@ -87,6 +87,21 @@ impl Sources {
         self
     }
 
+    /// [`with_remote`](Self::with_remote) for a deck already running —
+    /// `--docker-auto` (#92) adding a remote mid-run, on a scan tick,
+    /// rather than at startup.
+    pub fn add_remote(&mut self, remote: RemoteSource) {
+        self.remotes.push(remote);
+    }
+
+    /// Drops the named remote, which is the whole teardown: dropping a
+    /// [`RemoteSource`] stops its supervisor thread cleanly (see its
+    /// `Drop` impl) — the single removal path `--docker-auto` reuses
+    /// rather than inventing a second one.
+    pub fn remove_remote(&mut self, name: &str) {
+        self.remotes.retain(|r| r.name() != name);
+    }
+
     /// Opens a tailer for one roster row, picking the source from the key's
     /// prefix (`C:`/`H:`/`O:`, or `job1/` for a remote — whose own key sits
     /// behind the slash). Both halves of the row are needed: the key says

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -46,6 +46,7 @@ fn config(hermes_db: &std::path::Path) -> EngineConfig {
         replay: Replay::DEFAULT,
         remotes: Vec::new(),
         remote_flags: Vec::new(),
+        docker_auto: false,
     }
 }
 
@@ -163,6 +164,7 @@ fn shutdown_joins_promptly_with_no_sessions() {
             replay: Replay::DEFAULT,
             remotes: Vec::new(),
             remote_flags: Vec::new(),
+            docker_auto: false,
         },
         tx,
         rx,
@@ -204,6 +206,7 @@ fn a_hung_up_ui_ends_the_loop_via_the_failing_send() {
             replay: Replay::DEFAULT,
             remotes: Vec::new(),
             remote_flags: Vec::new(),
+            docker_auto: false,
         },
         tx,
         rx,
@@ -308,6 +311,7 @@ fn pane_config() -> EngineConfig {
         replay: Replay::DEFAULT,
         remotes: Vec::new(),
         remote_flags: Vec::new(),
+        docker_auto: false,
     }
 }
 

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -45,6 +45,7 @@ fn config(linger: f64, max_panes: usize) -> EngineConfig {
         replay: Replay::DEFAULT,
         remotes: Vec::new(),
         remote_flags: Vec::new(),
+        docker_auto: false,
     }
 }
 

--- a/tests/live_notify_check.rs
+++ b/tests/live_notify_check.rs
@@ -39,6 +39,7 @@ fn config() -> EngineConfig {
         replay: Replay::DEFAULT,
         remotes: Vec::new(),
         remote_flags: Vec::new(),
+        docker_auto: false,
     }
 }
 


### PR DESCRIPTION
########## ISSUE #92 ##########
Docker auto-discovery via container labels
Blocked by #91.
MODEL: sonnet5 — lifecycle logic (appear/disappear/rename/collision) plus the label-spoofing addendum push it past haiku territory, but every rule is enumerable and the validators come ready-made from #91.

**In plain terms:** Containers announce themselves: label a container and hermon starts following it automatically, stops when it dies.

---

**Why**
Manually adding `--remote docker:job1` per container defeats the point of a fleet monitor when containers churn.

**What to build**
Repo specifics: discovery logic in `src/remote/discover.rs` as pure functions over `docker ps` JSON (fixture-testable, no docker in unit tests), wired into the engine's scan tick (the ~1000ms roster poll in `engine.rs` — reuse the once-per-tick cost discipline, don't add a new timer). Spawning/teardown goes through #91's validated argv construction (`src/remote/spec.rs` helpers) and #90's `RemoteSource`; the name label is remote-influenced display text → #95's `render::sanitize`.
- `--docker-auto` flag: poll `docker ps --filter label=dev.hermon.agent --format {{json .}}` on the scan tick (bounded; docker absent → one warning, feature off).
- Containers appearing → spawn a remote (name = container name, honoring an optional `dev.hermon.agent.name` label); containers stopping → tear down the remote cleanly (its sessions age out via the fresh-window like any disconnect).
- Opt-in by design: only labeled containers are followed — never every container on the machine (privacy/noise; a dev may run dozens of unrelated containers).
- Works alongside explicit `--remote` specs; duplicate names resolved in favor of explicit.
- README: the label convention, a copy-paste `docker run` example, and a Dockerfile snippet (`COPY --from=… /hermon /usr/local/bin/`).

Seam note: reuse — never reimplement — #91's leading-dash/charset name validators on every name that comes out of `docker ps` (container names AND the `dev.hermon.agent.name` label); reuse #90's disconnect/fresh-window behavior for teardown rather than inventing a second removal path. This is the single sanctioned exception to #91's provenance invariant — keep the exception's constraints (validation + sanitization + explicit-wins) in one visible place with a comment pointing at the invariant.

**Out of scope**
podman/kubernetes auto-discovery (the `cmd:` transport covers them manually; revisit on demand). Watching docker events instead of polling (poll is the codebase's tempo).

**Acceptance criteria**
- Discovery logic unit-tested against fixture `docker ps` JSON (appear, disappear, rename, name-collision-with-explicit).
- Live check in the PR: start two labeled containers → both appear; stop one → it goes ⌁ then ages out; unlabeled container never appears.
- `cargo test` + CI green (clippy -D warnings, fmt).

## Security addendum (threat review 2026-08-31)

- **Label spoofing**: container labels inherit from image `LABEL` directives — running a third-party image can carry `dev.hermon.agent` and get auto-followed without the operator labeling anything. Combined with a hostile in-container binary this yields exactly the adversarial-agent scenario #90 hardens against. Consequences for this ticket:
  - README must state plainly: `--docker-auto` extends monitoring trust to every labeled image you run; explicit `--remote docker:<name>` is the paranoid mode.
  - Container names from `docker ps` output feed `docker exec` argv — apply the same leading-dash/charset validation as #91 (names are attacker-influenceable at image level via naming conventions, cheap to validate).
  - The `dev.hermon.agent.name` label value is remote-influenced display text: sanitize (#95) and length-cap it before it becomes a roster prefix; on collision with an explicit remote, explicit wins (already specced) and the spoofing attempt is logged visibly.