### PR TITLE
security: fix all six findings from the M10 pre-tag review

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -31,7 +31,7 @@ use crate::engine::{Engine, Event, Lifecycle, UiCmd};
 use crate::render::StyledLine;
 use crate::roster::RosterRow;
 use crate::source::Liveness;
-use crate::ui::pane::SCROLLBACK;
+use crate::ui::pane::trim_scrollback;
 use crate::view::{self, ViewState};
 
 const WINDOW_SIZE: [f32; 2] = [900.0, 620.0];
@@ -317,7 +317,9 @@ impl App {
     }
 
     /// Appends a fast tick's lines to a pane's buffer, dropping the oldest
-    /// past [`SCROLLBACK`]. Lines for any other key are stale — in flight
+    /// past [`crate::ui::pane::SCROLLBACK`] or
+    /// [`crate::ui::pane::SCROLLBACK_BYTES`],
+    /// whichever trips first. Lines for any other key are stale — in flight
     /// when the pane closed — and discarded.
     fn buffer_pane(&mut self, key: &str, lines: Vec<StyledLine>) {
         if !self.open_panes.iter().any(|open| open == key) {
@@ -326,9 +328,7 @@ impl App {
         let arrived = lines.len();
         let buffer = self.panes.entry(key.to_string()).or_default();
         buffer.extend(lines);
-        while buffer.len() > SCROLLBACK {
-            buffer.pop_front();
-        }
+        trim_scrollback(buffer);
         // The pane's wrap is cached, and a paused pane counts what it is not
         // showing: both live on the view, which the writer keeps honest.
         let view = self.pane_views.entry(key.to_string()).or_default();
@@ -597,6 +597,7 @@ mod tests {
     use super::*;
     use crate::engine::Cause;
     use crate::source::Attn;
+    use crate::ui::pane::{SCROLLBACK, SCROLLBACK_BYTES};
     use crate::view;
 
     fn row(key: &str, state: Liveness) -> RosterRow {
@@ -723,6 +724,29 @@ mod tests {
             lines: vec![StyledLine::default(); SCROLLBACK + 10],
         });
         assert_eq!(app.panes["C:aaa"].len(), SCROLLBACK);
+    }
+
+    /// A line count caps nothing when a remote picks how long its lines are:
+    /// 200 lines of 64 KiB is 13 MB in a buffer only 4% full by line count.
+    #[test]
+    fn pane_buffer_is_capped_in_bytes_as_well_as_lines() {
+        let mut app = app_with_pane("C:aaa");
+        let big = StyledLine(vec![crate::render::Seg::new(
+            crate::render::Sem::Plain,
+            "x".repeat(64 * 1024),
+        )]);
+        for _ in 0..200 {
+            app.apply_event(Event::PaneLines {
+                key: "C:aaa".to_string(),
+                lines: vec![big.clone(); 10],
+            });
+        }
+        let bytes: usize = app.panes["C:aaa"].iter().map(StyledLine::byte_len).sum();
+        assert!(
+            app.panes["C:aaa"].len() < SCROLLBACK,
+            "the line cap never trips"
+        );
+        assert!(bytes <= SCROLLBACK_BYTES, "{bytes} bytes held");
     }
 
     /// The cursor is what the engine tails: selecting a session opens its

--- a/src/remote/discover.rs
+++ b/src/remote/discover.rs
@@ -37,6 +37,8 @@
 
 use std::collections::{HashMap, HashSet};
 
+use chrono::DateTime;
+
 use crate::remote::spec::validate_name;
 use crate::render::{clip, sanitize};
 
@@ -66,6 +68,8 @@ struct PsEntry {
     names: String,
     #[serde(rename = "Labels", default)]
     labels: String,
+    #[serde(rename = "CreatedAt", default)]
+    created_at: String,
 }
 
 /// One running, labeled container as `docker ps` reported it, before any
@@ -81,6 +85,10 @@ pub struct Container {
     /// The raw `dev.hermon.agent.name` label value, if the container set
     /// one — not yet validated or sanitized.
     pub agent_name: Option<String>,
+    /// When docker says the container was created, as epoch seconds; `None`
+    /// when `docker ps` reported no parseable `CreatedAt`. The tiebreak for
+    /// a contested name — see [`reconcile`].
+    pub created: Option<i64>,
 }
 
 /// Parses `docker ps --format {{json .}}` output: one JSON object per
@@ -106,8 +114,23 @@ pub fn parse_ps(stdout: &str) -> Vec<Container> {
             // `validate_name`-clean token.
             name: e.names.split(',').next().unwrap_or_default().to_string(),
             agent_name: label_value(&e.labels, AGENT_NAME_LABEL),
+            created: parse_created(&e.created_at),
         })
         .collect()
+}
+
+/// `docker ps`'s `CreatedAt` — `2026-08-31 12:00:00 +0000 UTC` — as epoch
+/// seconds. The trailing zone *name* is dropped before parsing (chrono reads
+/// the numeric offset, which is the part that carries meaning) and anything
+/// this doesn't recognise is `None` rather than an error: a `docker ps` build
+/// that words the field differently costs discovery its tiebreak, not its
+/// containers.
+fn parse_created(raw: &str) -> Option<i64> {
+    let mut parts = raw.split_whitespace();
+    let stamp = format!("{} {} {}", parts.next()?, parts.next()?, parts.next()?);
+    DateTime::parse_from_str(&stamp, "%Y-%m-%d %H:%M:%S %z")
+        .ok()
+        .map(|dt| dt.timestamp())
 }
 
 /// Whether `docker ps`'s comma-joined `key=value,…` `Labels` field carries
@@ -186,7 +209,18 @@ pub fn reconcile(
         .map(|(id, name)| (name.clone(), id.clone()))
         .collect();
 
-    for c in containers {
+    // `managed` only protects a name its holder already held, so an impostor
+    // that starts in the *same* tick as its victim faces no incumbent at all
+    // and wins on `docker ps`'s newest-first ordering alone. Creation time is
+    // the one ordering it cannot forge — a container cannot be older than one
+    // it did not outlive — so contested names go to the older container.
+    // Unknown timestamps sort last, and the sort is stable, so a `docker ps`
+    // that reports no `CreatedAt` keeps today's listing order rather than
+    // handing the name to whoever sorts first.
+    let mut ordered: Vec<&Container> = containers.iter().collect();
+    ordered.sort_by_key(|c| c.created.unwrap_or(i64::MAX));
+
+    for c in ordered {
         if let Err(e) = validate_name(&c.name) {
             sync.warnings.push(format!(
                 "docker-auto: container {} has an invalid name {:?} ({e}), skipping",
@@ -257,8 +291,9 @@ mod tests {
     use super::*;
 
     fn ps_line(id: &str, name: &str, labels: &str) -> String {
+        let created = "2026-08-31 12:00:00 +0000 UTC";
         format!(
-            r#"{{"ID":"{id}","Names":"{name}","Labels":"{labels}","Image":"x","State":"running"}}"#
+            r#"{{"ID":"{id}","Names":"{name}","Labels":"{labels}","Image":"x","CreatedAt":"{created}","State":"running"}}"#
         )
     }
 
@@ -283,6 +318,18 @@ mod tests {
         );
         let containers = parse_ps(&stdout);
         assert_eq!(containers[0].agent_name, Some("worker1".to_string()));
+    }
+
+    #[test]
+    fn parse_ps_reads_the_creation_time() {
+        let stdout = ps_line("abc123", "job1", "dev.hermon.agent=1");
+        assert_eq!(parse_ps(&stdout)[0].created, Some(1_788_177_600));
+        // A docker that words the field differently, or omits it, costs the
+        // tiebreak — never the container.
+        let undated = r#"{"ID":"abc123","Names":"job1","Labels":"dev.hermon.agent=1"}"#;
+        let containers = parse_ps(undated);
+        assert_eq!(containers.len(), 1);
+        assert_eq!(containers[0].created, None);
     }
 
     #[test]
@@ -326,6 +373,15 @@ mod tests {
             id: id.to_string(),
             name: name.to_string(),
             agent_name: agent_name.map(str::to_string),
+            created: None,
+        }
+    }
+
+    /// The same container with docker's reported creation time on it.
+    fn born(id: &str, name: &str, agent_name: Option<&str>, created: i64) -> Container {
+        Container {
+            created: Some(created),
+            ..container(id, name, agent_name)
         }
     }
 
@@ -448,6 +504,42 @@ mod tests {
         let warning = sync.warnings.first().expect("the newcomer is warned about");
         assert!(warning.contains("\"evil\""), "{warning}");
         assert!(warning.contains("label spoofing"), "{warning}");
+    }
+
+    /// The incumbent seeding only helps a container that was already
+    /// `managed`. When the impostor starts in the same discovery tick as its
+    /// victim, neither is — and `docker ps`'s newest-first listing hands the
+    /// name to the newcomer. Creation time is the tiebreak.
+    #[test]
+    fn a_same_tick_impostor_loses_the_name_to_the_older_container() {
+        // Newest first, as `docker ps` lists it: the spoofer, started a
+        // minute ago carrying the victim's name, comes first.
+        let containers = vec![
+            born("spoof", "evil", Some("job1"), 2_000),
+            born("id1", "job1", None, 1_000),
+        ];
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert_eq!(sync.spawn.len(), 1, "{:?}", sync.spawn);
+        assert_eq!(sync.spawn[0].id, "id1", "the older container is followed");
+        assert_eq!(next.get("id1"), Some(&"job1".to_string()));
+        assert!(!next.contains_key("spoof"));
+        let warning = sync.warnings.first().expect("the newcomer is warned about");
+        assert!(warning.contains("\"evil\""), "{warning}");
+        assert!(warning.contains("label spoofing"), "{warning}");
+    }
+
+    #[test]
+    fn a_container_with_no_creation_time_cannot_outrank_a_dated_one() {
+        // An unknown age sorts last, so it never displaces a container whose
+        // age docker did report.
+        let containers = vec![
+            container("spoof", "evil", Some("job1")),
+            born("id1", "job1", None, 9_999),
+        ];
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert_eq!(sync.spawn.len(), 1);
+        assert_eq!(sync.spawn[0].id, "id1");
+        assert!(!next.contains_key("spoof"));
     }
 
     #[test]

--- a/src/remote/discover.rs
+++ b/src/remote/discover.rs
@@ -171,9 +171,20 @@ pub fn reconcile(
 ) -> (Sync, HashMap<String, String>) {
     let mut sync = Sync::default();
     let mut next: HashMap<String, String> = HashMap::new();
-    // Names claimed by a container already processed this tick, so two
-    // containers racing for the same label don't both spawn.
-    let mut claimed: HashSet<String> = HashSet::new();
+    // Name -> the container id holding it, so two containers racing for the
+    // same label don't both spawn. Seeded from `managed`: the incumbent owns
+    // its name before the loop starts, so whoever `docker ps` happens to
+    // list first cannot take it. That ordering is attacker-chosen — `docker
+    // ps` lists newest-first, so a container started *after* a legitimate
+    // one and carrying its `dev.hermon.agent.name` would otherwise be
+    // processed first, win the name, and get the victim torn down under it.
+    // A departed container's name stays claimed for the one tick it takes
+    // its removal to land, which costs a newcomer a tick and costs an
+    // impostor the hijack.
+    let mut claimed: HashMap<String, String> = managed
+        .iter()
+        .map(|(id, name)| (name.clone(), id.clone()))
+        .collect();
 
     for c in containers {
         if let Err(e) = validate_name(&c.name) {
@@ -207,14 +218,17 @@ pub fn reconcile(
             ));
             continue;
         }
-        if !claimed.insert(name.clone()) {
+        if let Some(holder) = claimed.get(&name)
+            && holder != &c.id
+        {
             sync.warnings.push(format!(
-                "docker-auto: container {:?} labeled name {name:?} collides with another \
-                 discovered container this tick, ignoring",
+                "docker-auto: container {:?} labeled name {name:?} collides with container \
+                 {holder}, which already holds it, ignoring (possible label spoofing)",
                 c.name
             ));
             continue;
         }
+        claimed.insert(name.clone(), c.id.clone());
 
         if managed.get(&c.id) != Some(&name) {
             if let Some(old) = managed.get(&c.id) {
@@ -405,6 +419,65 @@ mod tests {
         assert_eq!(sync.spawn.len(), 1);
         assert_eq!(sync.spawn[0].id, "id1");
         assert_eq!(next.len(), 1);
+        assert!(
+            sync.warnings.iter().any(|w| w.contains("collides")),
+            "{:?}",
+            sync.warnings
+        );
+    }
+
+    #[test]
+    fn a_later_container_cannot_steal_an_incumbents_name() {
+        // `docker ps` lists newest first, so the spoofer — started after the
+        // victim, carrying the victim's dev.hermon.agent.name — is the first
+        // container this loop sees. It must still lose.
+        let containers = vec![
+            container("spoof", "evil", Some("job1")),
+            container("id1", "job1", None),
+        ];
+        let managed = HashMap::from([("id1".to_string(), "job1".to_string())]);
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &managed);
+        assert!(sync.spawn.is_empty(), "the impostor never spawns");
+        assert!(
+            sync.remove.is_empty(),
+            "and the incumbent is not torn down: {:?}",
+            sync.remove
+        );
+        assert_eq!(next.get("id1"), Some(&"job1".to_string()));
+        assert!(!next.contains_key("spoof"));
+        let warning = sync.warnings.first().expect("the newcomer is warned about");
+        assert!(warning.contains("\"evil\""), "{warning}");
+        assert!(warning.contains("label spoofing"), "{warning}");
+    }
+
+    #[test]
+    fn an_incumbent_keeps_its_name_even_when_it_is_listed_last() {
+        // Same shape, but the incumbent's name comes from its own label
+        // rather than the container name — the label is the part a hostile
+        // image gets to choose, so both spellings have to hold.
+        let containers = vec![
+            container("spoof", "evil", Some("worker1")),
+            container("id1", "job1", Some("worker1")),
+        ];
+        let managed = HashMap::from([("id1".to_string(), "worker1".to_string())]);
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &managed);
+        assert!(sync.spawn.is_empty());
+        assert!(sync.remove.is_empty());
+        assert_eq!(next.get("id1"), Some(&"worker1".to_string()));
+    }
+
+    #[test]
+    fn an_explicit_remotes_cleaned_name_is_the_one_a_label_collides_with() {
+        // `--remote docker:job1:a/b` runs under "a-b", not "a/b", so that is
+        // the string the explicit set carries and the string a spoofed label
+        // has to be refused against.
+        let spec = crate::remote::spec::parse_spec("docker:job1:a/b").expect("parses");
+        assert_eq!(spec.name, "a-b");
+        let explicit = HashSet::from([spec.name]);
+        let containers = vec![container("spoof", "evil", Some("a-b"))];
+        let (sync, next) = reconcile(&containers, &explicit, &HashMap::new());
+        assert!(sync.spawn.is_empty(), "explicit --remote wins");
+        assert!(next.is_empty());
         assert!(
             sync.warnings.iter().any(|w| w.contains("collides")),
             "{:?}",

--- a/src/remote/discover.rs
+++ b/src/remote/discover.rs
@@ -214,40 +214,31 @@ pub fn reconcile(
     // and wins on `docker ps`'s newest-first ordering alone. Creation time is
     // the one ordering it cannot forge — a container cannot be older than one
     // it did not outlive — so contested names go to the older container.
-    // Unknown timestamps sort last, and the sort is stable, so a `docker ps`
-    // that reports no `CreatedAt` keeps today's listing order rather than
-    // handing the name to whoever sorts first.
+    // Unknown timestamps sort last, so a container docker did date always
+    // outranks one it didn't.
     let mut ordered: Vec<&Container> = containers.iter().collect();
     ordered.sort_by_key(|c| c.created.unwrap_or(i64::MAX));
 
-    for c in ordered {
-        if let Err(e) = validate_name(&c.name) {
-            sync.warnings.push(format!(
-                "docker-auto: container {} has an invalid name {:?} ({e}), skipping",
-                c.id, c.name
-            ));
-            continue;
-        }
+    let contenders: Vec<(&Container, String)> = ordered
+        .into_iter()
+        .filter_map(|c| resolve_name(c, &mut sync.warnings).map(|name| (c, name)))
+        .collect();
+    let untieable = untieable_names(&contenders, &claimed);
 
-        let name = match &c.agent_name {
-            Some(raw) => match validate_name(raw) {
-                Ok(()) => clip(&sanitize(raw), MAX_LABEL_NAME_LEN),
-                Err(e) => {
-                    sync.warnings.push(format!(
-                        "docker-auto: container {:?} has an invalid {AGENT_NAME_LABEL} label \
-                         {raw:?} ({e}), falling back to the container name",
-                        c.name
-                    ));
-                    c.name.clone()
-                }
-            },
-            None => c.name.clone(),
-        };
-
+    for (c, name) in contenders {
         if explicit.contains(&name) {
             sync.warnings.push(format!(
                 "docker-auto: container {:?} labeled name {name:?} collides with an explicit \
                  --remote, ignoring (possible label spoofing)",
+                c.name
+            ));
+            continue;
+        }
+        if untieable.contains(&name) {
+            sync.warnings.push(format!(
+                "docker-auto: container {:?} claims name {name:?} against a container it cannot \
+                 be ordered against (equal or unknown creation time), refusing both — docker's \
+                 listing order is not a tiebreak (possible label spoofing)",
                 c.name
             ));
             continue;
@@ -284,6 +275,76 @@ pub fn reconcile(
     }
 
     (sync, next)
+}
+
+/// The roster name one container would run under: its validated
+/// `dev.hermon.agent.name` label if it has a usable one, its own container
+/// name otherwise. `None` when the container name itself is unusable, since
+/// that name reaches argv. Anything skipped or fallen back on is warned about
+/// here, once, before any name is contested.
+fn resolve_name(c: &Container, warnings: &mut Vec<String>) -> Option<String> {
+    if let Err(e) = validate_name(&c.name) {
+        warnings.push(format!(
+            "docker-auto: container {} has an invalid name {:?} ({e}), skipping",
+            c.id, c.name
+        ));
+        return None;
+    }
+    let Some(raw) = &c.agent_name else {
+        return Some(c.name.clone());
+    };
+    match validate_name(raw) {
+        Ok(()) => Some(clip(&sanitize(raw), MAX_LABEL_NAME_LEN)),
+        Err(e) => {
+            warnings.push(format!(
+                "docker-auto: container {:?} has an invalid {AGENT_NAME_LABEL} label \
+                 {raw:?} ({e}), falling back to the container name",
+                c.name
+            ));
+            Some(c.name.clone())
+        }
+    }
+}
+
+/// The names no container may have this tick: those whose two oldest
+/// contenders cannot be told apart — the same second on docker's
+/// second-granular `CreatedAt`, or both undated.
+///
+/// Creation time is the only ordering an impostor cannot forge, and a tie
+/// takes it away. What is left underneath is `docker ps`'s own newest-first
+/// listing, which is precisely the ordering the attacker chooses by starting
+/// its container when it likes. So a tie refuses *both* contenders rather
+/// than letting the list decide: the victim loses its name for as long as the
+/// impostor keeps claiming it, visibly and with a warning, which beats the
+/// impostor silently being followed under it.
+///
+/// A name an incumbent already holds is never untieable — `claimed` was
+/// seeded from `managed`, and being followed already is a tiebreak of its
+/// own that no newcomer of any age gets to overturn.
+fn untieable_names(
+    contenders: &[(&Container, String)],
+    claimed: &HashMap<String, String>,
+) -> HashSet<String> {
+    let mut oldest: HashMap<&str, Option<i64>> = HashMap::new();
+    let mut untieable = HashSet::new();
+    for (c, name) in contenders {
+        if claimed.contains_key(name) {
+            continue;
+        }
+        match oldest.get(name.as_str()) {
+            // `contenders` is sorted oldest-first, so the entry already here
+            // is the one to beat: equal to it (both dated the same second, or
+            // both undated) and neither can claim the name.
+            Some(best) if *best == c.created => {
+                untieable.insert(name.clone());
+            }
+            Some(_) => {}
+            None => {
+                oldest.insert(name.as_str(), c.created);
+            }
+        }
+    }
+    untieable
 }
 
 #[cfg(test)]
@@ -466,20 +527,125 @@ mod tests {
     }
 
     #[test]
-    fn two_containers_racing_for_the_same_label_only_spawn_the_first() {
+    fn two_undated_containers_racing_for_the_same_label_are_both_refused() {
+        // Nothing tells these two apart but `docker ps`'s listing order, and
+        // that is the attacker's to choose. Neither is followed.
         let containers = vec![
             container("id1", "job1", Some("worker")),
             container("id2", "job2", Some("worker")),
         ];
         let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
-        assert_eq!(sync.spawn.len(), 1);
-        assert_eq!(sync.spawn[0].id, "id1");
-        assert_eq!(next.len(), 1);
+        assert!(sync.spawn.is_empty(), "{:?}", sync.spawn);
+        assert!(next.is_empty());
+        for name in ["\"job1\"", "\"job2\""] {
+            assert!(
+                sync.warnings
+                    .iter()
+                    .any(|w| w.contains(name) && w.contains("refusing both")),
+                "{name} was not logged as refused: {:?}",
+                sync.warnings
+            );
+        }
+    }
+
+    /// Docker's `CreatedAt` is second-granular, so two containers started
+    /// inside the same second carry the same timestamp and the tiebreak has
+    /// nothing to work with — the case an impostor reaches by starting
+    /// alongside its victim rather than after it.
+    #[test]
+    fn two_containers_created_in_the_same_second_are_both_refused() {
+        let containers = vec![
+            born("spoof", "evil", Some("job1"), 1_000),
+            born("id1", "job1", None, 1_000),
+        ];
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert!(sync.spawn.is_empty(), "{:?}", sync.spawn);
+        assert!(next.is_empty());
         assert!(
-            sync.warnings.iter().any(|w| w.contains("collides")),
-            "{:?}",
+            sync.warnings
+                .iter()
+                .filter(|w| w.contains("refusing both"))
+                .count()
+                == 2,
+            "both contenders are warned about: {:?}",
             sync.warnings
         );
+    }
+
+    /// A third, younger container doesn't inherit a name whose two oldest
+    /// claimants deadlocked — the ambiguity is about who the name belongs to,
+    /// not about which of the losers is next in line.
+    #[test]
+    fn a_tie_at_the_top_refuses_the_whole_contested_name() {
+        let containers = vec![
+            born("id3", "job3", Some("worker"), 3_000),
+            born("id1", "job1", Some("worker"), 1_000),
+            born("id2", "job2", Some("worker"), 1_000),
+        ];
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert!(sync.spawn.is_empty(), "{:?}", sync.spawn);
+        assert!(next.is_empty());
+    }
+
+    /// A tie among the losers is not a tie for the name: the unique oldest
+    /// still wins it.
+    #[test]
+    fn a_tie_below_the_oldest_container_does_not_refuse_the_name() {
+        let containers = vec![
+            born("spoof1", "evil1", Some("job1"), 2_000),
+            born("spoof2", "evil2", Some("job1"), 2_000),
+            born("id1", "job1", None, 1_000),
+        ];
+        let (sync, next) = reconcile(&containers, &HashSet::new(), &HashMap::new());
+        assert_eq!(sync.spawn.len(), 1, "{:?}", sync.spawn);
+        assert_eq!(sync.spawn[0].id, "id1");
+        assert_eq!(next.get("id1"), Some(&"job1".to_string()));
+    }
+
+    /// Incumbency outranks the tiebreak entirely. A container already being
+    /// followed keeps its name against a newcomer of any age — including one
+    /// planted with an *older* creation time, which is otherwise the winning
+    /// move, and one that ties it.
+    #[test]
+    fn an_incumbent_beats_a_newcomer_of_any_age() {
+        let managed = HashMap::from([("id1".to_string(), "job1".to_string())]);
+        for spoof_created in [None, Some(1), Some(1_000), Some(9_999)] {
+            let containers = vec![
+                Container {
+                    created: spoof_created,
+                    ..container("spoof", "evil", Some("job1"))
+                },
+                born("id1", "job1", None, 1_000),
+            ];
+            let (sync, next) = reconcile(&containers, &HashSet::new(), &managed);
+            assert!(sync.spawn.is_empty(), "{spoof_created:?}: {:?}", sync.spawn);
+            assert!(
+                sync.remove.is_empty(),
+                "{spoof_created:?}: {:?}",
+                sync.remove
+            );
+            assert_eq!(next.get("id1"), Some(&"job1".to_string()));
+            assert!(!next.contains_key("spoof"));
+        }
+    }
+
+    /// The pre-planted case: an impostor already running, undated, when its
+    /// victim first appears. It faces no incumbent — so the tie is all that
+    /// stands between it and owning the name from the very first tick, and
+    /// staying incumbent forever after.
+    #[test]
+    fn a_pre_planted_undated_impostor_never_becomes_the_incumbent() {
+        let containers = vec![
+            container("id1", "job1", None),
+            container("spoof", "evil", Some("job1")),
+        ];
+        let mut managed = HashMap::new();
+        for tick in 0..3 {
+            let (sync, next) = reconcile(&containers, &HashSet::new(), &managed);
+            assert!(sync.spawn.is_empty(), "tick {tick}: {:?}", sync.spawn);
+            assert!(next.is_empty(), "tick {tick}: {next:?}");
+            managed = next;
+        }
     }
 
     #[test]

--- a/src/remote/source.rs
+++ b/src/remote/source.rs
@@ -871,10 +871,18 @@ fn write_cmd(stdin: &mut ChildStdin, cmd: &HostCmd) -> bool {
 /// frame is skipped, an oversized one is counted, and EOF just ends the
 /// connection so the supervisor can respawn.
 ///
-/// `live` is this connection's own flag, checked once per frame: a reader
-/// abandoned by [`join_before`] may still be parked on a pipe a grandchild
-/// holds open, and its child's frames must not reach a state that has since
-/// moved on to a new connection.
+/// `live` is this connection's own flag, checked both before a frame is read
+/// and again once it arrives: a reader abandoned by [`join_before`] may still
+/// be parked on a pipe a grandchild holds open, and its child's frames must
+/// not reach a state that has since moved on to a new connection.
+///
+/// The second check is the one that matters. Checking only at the loop head
+/// leaves a whole blocked [`read_frame`] between the test and the write, so
+/// an orphan parked on that pipe when its connection was torn down still gets
+/// to fold exactly one attacker-chosen frame — a `Tail` into a live pane, a
+/// `Snap` replacing the roster, a `Hello` clearing the evidence of the last
+/// child's abuse — into the state of the connection that replaced it, once
+/// per reconnect.
 fn read_frames<R: BufRead>(
     mut reader: R,
     shared: &Arc<Mutex<Shared>>,
@@ -884,7 +892,11 @@ fn read_frames<R: BufRead>(
     let mut buf = Vec::new();
     let mut reopened = false;
     while live.load(Ordering::Relaxed) {
-        match read_frame(&mut reader, &mut buf) {
+        let frame = read_frame(&mut reader, &mut buf);
+        if !live.load(Ordering::Relaxed) {
+            return;
+        }
+        match frame {
             Frame::Eof => return,
             Frame::Oversized => {
                 lock(shared).oversized += 1;
@@ -1773,6 +1785,142 @@ mod tests {
             started.elapsed() < Duration::from_secs(5),
             "Drop waited {:?} on an orphan's pipe",
             started.elapsed()
+        );
+    }
+
+    /// Stands in for the pipe an abandoned reader is parked on: the read is
+    /// already blocked when the connection is torn down, so `live` goes false
+    /// *during* it and the frame only lands afterwards. That window is the
+    /// whole bug — a check at the loop head is on the wrong side of it.
+    struct TornDownMidRead<'a> {
+        live: &'a AtomicBool,
+        bytes: Cursor<Vec<u8>>,
+    }
+
+    impl Read for TornDownMidRead<'_> {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.live.store(false, Ordering::Relaxed);
+            self.bytes.read(buf)
+        }
+    }
+
+    impl BufRead for TornDownMidRead<'_> {
+        fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+            self.live.store(false, Ordering::Relaxed);
+            self.bytes.fill_buf()
+        }
+
+        fn consume(&mut self, n: usize) {
+            self.bytes.consume(n);
+        }
+    }
+
+    fn framed(msg: &AgentMsg) -> Vec<u8> {
+        format!("{}\n", crate::remote::proto::encode_agent_msg(msg)).into_bytes()
+    }
+
+    fn ghost_tail() -> AgentMsg {
+        AgentMsg::Tail {
+            key: "C:1".into(),
+            lines: vec![StyledLine(vec![Seg {
+                sem: Sem::Plain,
+                text: "GHOST".into(),
+            }])],
+        }
+    }
+
+    /// A pane already open on the connection that replaced the dead one.
+    fn with_open_pane() -> Arc<Mutex<Shared>> {
+        let shared = Arc::new(Mutex::new(connected()));
+        lock(&shared)
+            .tails
+            .insert("C:1".into(), TailQueue::default());
+        shared
+    }
+
+    #[test]
+    fn an_orphan_reader_cannot_fold_one_last_frame_into_the_live_connection() {
+        let (cmds, _rx) = mpsc::sync_channel(CMD_QUEUE);
+
+        let shared = with_open_pane();
+        let live = AtomicBool::new(true);
+        let reader = TornDownMidRead {
+            live: &live,
+            bytes: Cursor::new(framed(&ghost_tail())),
+        };
+        read_frames(reader, &shared, &cmds, &live);
+        let ghosted = lock(&shared).tails["C:1"].lines.clone();
+        assert!(
+            ghosted.is_empty(),
+            "an orphan wrote into the new connection's pane: {ghosted:?}"
+        );
+
+        // Not a reader that silently drops everything: the same frame on a
+        // connection that is still live does land.
+        let shared = with_open_pane();
+        let live = AtomicBool::new(true);
+        read_frames(Cursor::new(framed(&ghost_tail())), &shared, &cmds, &live);
+        assert_eq!(lock(&shared).tails["C:1"].lines.len(), 1);
+    }
+
+    #[test]
+    fn an_orphans_oversized_frame_is_not_charged_to_the_live_connection() {
+        // The oversized counter is a state write too, and it happens before
+        // the `continue` that would have re-tested `live`.
+        let (cmds, _rx) = mpsc::sync_channel(CMD_QUEUE);
+        let shared = with_open_pane();
+        let live = AtomicBool::new(true);
+        let mut huge = vec![b'x'; MAX_FRAME_BYTES + 10];
+        huge.push(b'\n');
+        read_frames(
+            TornDownMidRead {
+                live: &live,
+                bytes: Cursor::new(huge),
+            },
+            &shared,
+            &cmds,
+            &live,
+        );
+        assert_eq!(lock(&shared).oversized, 0);
+    }
+
+    /// The same property through real processes: the `sh` exits at once, its
+    /// backgrounded subshell inherits stdout and writes a frame long after
+    /// the connection was torn down. The reader parked on that pipe is a
+    /// detached orphan by then, and what it reads must go nowhere.
+    #[test]
+    fn a_grandchild_writing_after_teardown_cannot_reach_the_hosts_state() {
+        let shared = with_open_pane();
+        let (cmds, rx) = mpsc::sync_channel(CMD_QUEUE);
+        let cmd_rx = Arc::new(Mutex::new(rx));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let ghost = crate::remote::proto::encode_agent_msg(&ghost_tail());
+        let child = Command::new("sh")
+            .args([
+                "-c",
+                &format!("(sleep 1; printf '%s\\n' '{ghost}') & exit 0"),
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("sh spawns");
+
+        // The child never EOFs its stdout, so nothing but `stop` ends this
+        // connection — exactly the shape `Drop` and a quit take.
+        let quitter = Arc::clone(&stop);
+        thread::spawn(move || {
+            thread::sleep(Duration::from_millis(200));
+            quitter.store(true, Ordering::Relaxed);
+        });
+        run_connection(child, &shared, &cmd_rx, &cmds, &stop);
+
+        thread::sleep(Duration::from_millis(1500)); // past the grandchild's write
+        let ghosted = lock(&shared).tails["C:1"].lines.clone();
+        assert!(
+            ghosted.is_empty(),
+            "a dead child's grandchild reached live state: {ghosted:?}"
         );
     }
 

--- a/src/remote/source.rs
+++ b/src/remote/source.rs
@@ -24,10 +24,10 @@
 //! trusted.
 
 use std::collections::{HashMap, VecDeque};
-use std::io::{BufRead, BufReader, Read, Write};
-use std::process::{Child, Command, Stdio};
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, Sender};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -54,6 +54,23 @@ pub const MAX_SNAP_SESSIONS: usize = 10_000;
 /// screenful; a flood is the agent's problem, not the host's memory.
 const MAX_TAIL_LINES: usize = 4_096;
 
+/// Bytes held per open tail, evicted oldest-first alongside
+/// [`MAX_TAIL_LINES`] — whichever cap trips first. A line count alone bounds
+/// nothing: one wire line can carry most of a [`MAX_FRAME_BYTES`] frame, so
+/// 4096 of them is gigabytes, not megabytes.
+const MAX_TAIL_BYTES: usize = 4 * 1024 * 1024;
+
+/// Longest single tail line the host keeps, clipped at ingest. A pane draws
+/// a screenful; the rest is a hostile agent spending our memory a megabyte
+/// per frame.
+const MAX_TAIL_LINE_BYTES: usize = 64 * 1024;
+
+/// Host commands queued for a child before new ones are dropped. Bounded
+/// because the agent influences how many get queued — every `Hello` asks for
+/// one `OpenTail` per open pane — and because the one thread draining it can
+/// be blocked indefinitely by a child that never reads its stdin.
+const CMD_QUEUE: usize = 64;
+
 /// Reconnect backoff floor and ceiling, doubling in between.
 const BACKOFF_MIN: Duration = Duration::from_secs(1);
 const BACKOFF_MAX: Duration = Duration::from_secs(30);
@@ -70,6 +87,12 @@ const MAX_STDERR_BYTES: usize = 4096;
 /// Instant exits in a row before respawns are pinned at [`BACKOFF_MAX`] for
 /// good: a remote that can't start must not become a respawn storm.
 const INSTANT_EXIT_STRIKES: u32 = 3;
+
+/// How long teardown lets the writer thread get its `Shutdown` out before
+/// the child is killed anyway. Never a wait on the thread itself: a child
+/// that stopped reading its stdin leaves that write blocked until the kill
+/// breaks the pipe.
+const SHUTDOWN_GRACE: Duration = Duration::from_millis(200);
 
 /// A connection that lasted this long counts as healthy, so the next
 /// failure starts the backoff over rather than resuming where it left off.
@@ -115,6 +138,8 @@ struct TailQueue {
     /// going permanently blank when the agent restarts under it.
     replay: Replay,
     lines: VecDeque<StyledLine>,
+    /// Running total of `lines`' text, so the byte cap costs no rescan.
+    bytes: usize,
 }
 
 /// Everything the reader thread writes and the roster reads.
@@ -128,6 +153,9 @@ struct Shared {
     tails: HashMap<String, TailQueue>,
     /// Frames refused for exceeding [`MAX_FRAME_BYTES`], this connection.
     oversized: u64,
+    /// Stderr bytes read past [`MAX_STDERR_BYTES`] and thrown away — a child
+    /// shouting into fd 2 to grow host memory, in the numbers that says so.
+    stderr_dropped: u64,
     /// The newest `Snap` was truncated at [`MAX_SNAP_SESSIONS`].
     truncated: bool,
     /// Seconds the remote clock runs ahead of ours, warned once per
@@ -152,7 +180,7 @@ struct Shared {
 pub struct RemoteSource {
     name: String,
     shared: Arc<Mutex<Shared>>,
-    cmds: Sender<HostCmd>,
+    cmds: SyncSender<HostCmd>,
     stop: Arc<AtomicBool>,
     supervisor: Option<JoinHandle<()>>,
 }
@@ -165,7 +193,11 @@ impl RemoteSource {
         let name = clean_name(&name.into());
         let shared = Arc::new(Mutex::new(Shared::default()));
         let stop = Arc::new(AtomicBool::new(false));
-        let (cmds, cmd_rx) = mpsc::channel();
+        // Bounded, and the receiver is shared rather than owned by the
+        // supervisor: each connection hands it to a writer thread that can
+        // outlive the connection's own teardown (see `write_cmds`).
+        let (cmds, cmd_rx) = mpsc::sync_channel(CMD_QUEUE);
+        let cmd_rx = Arc::new(Mutex::new(cmd_rx));
 
         let supervisor = {
             let shared = Arc::clone(&shared);
@@ -241,12 +273,16 @@ impl Source for RemoteSource {
             session_id.to_string(),
             TailQueue {
                 replay,
-                lines: VecDeque::new(),
+                ..TailQueue::default()
             },
         );
         drop(shared);
 
-        let _ = self.cmds.send(HostCmd::OpenTail {
+        // Dropped rather than queued when the channel is full: a command the
+        // host cannot get out to a child that has stopped reading its stdin
+        // is a command that child was never going to act on, and the
+        // supervisor is about to notice and respawn it.
+        let _ = self.cmds.try_send(HostCmd::OpenTail {
             key: session_id.to_string(),
             replay,
         });
@@ -272,7 +308,7 @@ impl Drop for RemoteSource {
 pub struct RemoteTailer {
     key: String,
     shared: Arc<Mutex<Shared>>,
-    cmds: Sender<HostCmd>,
+    cmds: SyncSender<HostCmd>,
     down_notified: bool,
 }
 
@@ -283,7 +319,10 @@ impl Tailer for RemoteTailer {
         let mut out: Vec<StyledLine> = shared
             .tails
             .get_mut(&self.key)
-            .map(|q| q.lines.drain(..).collect())
+            .map(|q| {
+                q.bytes = 0;
+                q.lines.drain(..).collect()
+            })
             .unwrap_or_default();
         drop(shared);
 
@@ -303,7 +342,7 @@ impl Tailer for RemoteTailer {
 impl Drop for RemoteTailer {
     fn drop(&mut self) {
         lock(&self.shared).tails.remove(&self.key);
-        let _ = self.cmds.send(HostCmd::CloseTail {
+        let _ = self.cmds.try_send(HostCmd::CloseTail {
             key: self.key.clone(),
         });
     }
@@ -358,7 +397,12 @@ impl Backoff {
 
 /// `/` separates a remote's name from the source key it prefixes, so it
 /// cannot appear inside the name itself; control bytes can't either.
-fn clean_name(name: &str) -> String {
+///
+/// `pub(crate)` because [`crate::remote::spec`] has to apply the identical
+/// cleaning to a `:name` suffix: the name in a `RemoteSpec` is only useful
+/// as a collision key if it is already the name the `RemoteSource` will run
+/// under.
+pub(crate) fn clean_name(name: &str) -> String {
     sanitize(name).replace('/', "-")
 }
 
@@ -386,15 +430,37 @@ fn sanitize_meta(mut s: SessionMeta) -> SessionMeta {
     s
 }
 
-/// `Seg::new` is the sanitizing constructor, so rebuilding the line through
-/// it is the laundering — the wire's own segments are never stored as-is.
+/// Rebuilding the line through [`sanitize`] is the laundering — the wire's
+/// own segments are never stored as-is — and the result is clipped to
+/// [`MAX_TAIL_LINE_BYTES`]. The clip goes here, on the sanitized text,
+/// because sanitizing *grows* a hostile line: every control byte becomes a
+/// three-byte U+FFFD, so a cap applied to what arrived would not bound what
+/// we keep.
 fn sanitize_line(line: StyledLine) -> StyledLine {
-    StyledLine(
-        line.0
-            .into_iter()
-            .map(|s| Seg::new(s.sem, s.text))
-            .collect(),
-    )
+    let mut budget = MAX_TAIL_LINE_BYTES;
+    let mut segs = Vec::with_capacity(line.0.len());
+    for seg in line.0 {
+        if budget == 0 {
+            break;
+        }
+        let text = clip_bytes(sanitize(&seg.text), budget);
+        budget -= text.len();
+        segs.push(Seg { sem: seg.sem, text });
+    }
+    StyledLine(segs)
+}
+
+/// Truncates to at most `budget` bytes, backing up to the nearest char
+/// boundary — a byte cap on text that is still UTF-8 afterwards.
+fn clip_bytes(mut text: String, budget: usize) -> String {
+    if text.len() > budget {
+        let mut end = budget;
+        while end > 0 && !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        text.truncate(end);
+    }
+    text
 }
 
 /// The remote's own roster lines: link state first, then whatever the
@@ -434,6 +500,12 @@ fn notices(name: &str, shared: &Shared) -> Vec<String> {
             "⚠ {name} — dropped {} frame(s) over {} MiB",
             shared.oversized,
             MAX_FRAME_BYTES / (1024 * 1024)
+        ));
+    }
+    if shared.stderr_dropped > 0 {
+        out.push(format!(
+            "⚠ {name} — dropped {} stderr byte(s) over {MAX_STDERR_BYTES}",
+            shared.stderr_dropped
         ));
     }
     if let Some(skew) = shared.skew {
@@ -482,6 +554,7 @@ fn apply_frame(shared: &mut Shared, msg: AgentMsg, now: f64) -> Applied {
             // A fresh Hello resets everything that described the *previous*
             // connection; the snapshot stays, so the deck doesn't blink.
             shared.oversized = 0;
+            shared.stderr_dropped = 0;
             shared.truncated = false;
             shared.skew = None;
             shared.spawn_error = None;
@@ -514,10 +587,18 @@ fn apply_frame(shared: &mut Shared, msg: AgentMsg, now: f64) -> Applied {
             // everything and the host nothing.
             if let Some(queue) = shared.tails.get_mut(&key) {
                 for line in lines {
-                    if queue.lines.len() >= MAX_TAIL_LINES {
-                        queue.lines.pop_front();
+                    let line = sanitize_line(line);
+                    queue.bytes += line.byte_len();
+                    queue.lines.push_back(line);
+                    // Both caps, oldest-first, whichever trips: 4096 lines is
+                    // a bound on nothing when the agent chooses how long a
+                    // line is.
+                    while queue.lines.len() > MAX_TAIL_LINES || queue.bytes > MAX_TAIL_BYTES {
+                        let Some(dropped) = queue.lines.pop_front() else {
+                            break;
+                        };
+                        queue.bytes -= dropped.byte_len();
                     }
-                    queue.lines.push_back(sanitize_line(line));
                 }
             }
             Applied::Nothing
@@ -587,8 +668,8 @@ fn lock(shared: &Mutex<Shared>) -> MutexGuard<'_, Shared> {
 fn supervise(
     mut transport: Command,
     shared: &Arc<Mutex<Shared>>,
-    cmd_rx: &Receiver<HostCmd>,
-    cmds: &Sender<HostCmd>,
+    cmd_rx: &Arc<Mutex<Receiver<HostCmd>>>,
+    cmds: &SyncSender<HostCmd>,
     stop: &Arc<AtomicBool>,
 ) {
     let mut backoff = Backoff::new();
@@ -634,15 +715,19 @@ fn supervise(
     }
 }
 
-/// Drives one child: a reader thread on its stdout, another draining its
-/// stderr for the "binary missing" diagnosis, host commands onto its stdin,
-/// until either end goes away. Returns whatever the child wrote to stderr
-/// (capped, may be empty) so the caller can classify why it died.
+/// Drives one child: a reader thread on its stdout, one draining its stderr
+/// for the "binary missing" diagnosis, one writing host commands onto its
+/// stdin, until either end goes away. Returns whatever the child wrote to
+/// stderr (capped, may be empty) so the caller can classify why it died.
+///
+/// This thread itself only ever waits on flags and sleeps — it must stay
+/// promptly interruptible, because it is the thread [`RemoteSource::drop`]
+/// joins, and an agent must not be able to make quitting hermon impossible.
 fn run_connection(
     mut child: Child,
     shared: &Arc<Mutex<Shared>>,
-    cmd_rx: &Receiver<HostCmd>,
-    cmds: &Sender<HostCmd>,
+    cmd_rx: &Arc<Mutex<Receiver<HostCmd>>>,
+    cmds: &SyncSender<HostCmd>,
     stop: &Arc<AtomicBool>,
 ) -> String {
     let reading = Arc::new(AtomicBool::new(true));
@@ -662,34 +747,38 @@ fn run_connection(
         thread::spawn(move || read_stderr(BufReader::new(stderr), &buf))
     });
 
-    let mut stdin = child.stdin.take();
+    let writer = child.stdin.take().map(|stdin| {
+        let cmd_rx = Arc::clone(cmd_rx);
+        let reading = Arc::clone(&reading);
+        let stop = Arc::clone(stop);
+        thread::spawn(move || write_cmds(stdin, &cmd_rx, &reading, &stop))
+    });
+
     while reading.load(Ordering::Relaxed) && !stop.load(Ordering::Relaxed) {
-        let cmd = match cmd_rx.recv_timeout(CMD_TICK) {
-            Ok(cmd) => cmd,
-            Err(RecvTimeoutError::Timeout) => continue,
-            Err(RecvTimeoutError::Disconnected) => break,
-        };
-        let Some(writer) = stdin.as_mut() else { break };
-        let line = encode_host_cmd(&cmd);
-        if writeln!(writer, "{line}").is_err() || writer.flush().is_err() {
-            break; // the child stopped listening; the reader will notice too
-        }
+        thread::sleep(CMD_TICK);
     }
 
-    // Ask the agent to leave, then make sure it did: dropping stdin is the
-    // EOF it exits on, and the kill covers an agent that ignores both.
-    if let Some(writer) = stdin.as_mut() {
-        let _ = writeln!(writer, "{}", encode_host_cmd(&HostCmd::Shutdown));
-        let _ = writer.flush();
+    // Give the writer its moment to say `Shutdown` and close stdin — the EOF
+    // a well-behaved agent exits on — but bounded, and never as a join: a
+    // child that stopped reading its stdin has that write blocked until the
+    // kill below breaks the pipe. The kill covers an agent that ignores both.
+    let grace = Instant::now() + SHUTDOWN_GRACE;
+    while writer.as_ref().is_some_and(|w| !w.is_finished()) && Instant::now() < grace {
+        thread::sleep(CMD_TICK.min(grace.saturating_duration_since(Instant::now())));
     }
-    drop(stdin);
     let _ = child.kill();
     let _ = child.wait();
     if let Some(reader) = reader {
         let _ = reader.join();
     }
-    if let Some(reader) = stderr_reader {
-        let _ = reader.join();
+    if let Some(writer) = writer {
+        let _ = writer.join();
+    }
+    if let Some(reader) = stderr_reader
+        && let Ok(dropped) = reader.join()
+        && dropped > 0
+    {
+        lock(shared).stderr_dropped += dropped;
     }
     stderr_buf
         .lock()
@@ -697,11 +786,52 @@ fn run_connection(
         .clone()
 }
 
+/// Host commands onto one child's stdin, on a thread of their own.
+///
+/// The write is blocking and cannot be made otherwise without a syscall this
+/// crate doesn't take a dependency for, so the answer is *where* it blocks:
+/// a child that never reads its stdin fills the pipe and parks this thread
+/// forever, and [`run_connection`] deliberately does not wait on it before
+/// killing the child. The kill breaks the pipe, the write fails, this thread
+/// ends. Nothing an agent does can stall the supervisor or [`Drop`].
+fn write_cmds(
+    mut stdin: ChildStdin,
+    cmd_rx: &Mutex<Receiver<HostCmd>>,
+    reading: &AtomicBool,
+    stop: &AtomicBool,
+) {
+    while reading.load(Ordering::Relaxed) && !stop.load(Ordering::Relaxed) {
+        let cmd = {
+            let rx = cmd_rx
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            match rx.recv_timeout(CMD_TICK) {
+                Ok(cmd) => cmd,
+                Err(RecvTimeoutError::Timeout) => continue,
+                Err(RecvTimeoutError::Disconnected) => break,
+            }
+        };
+        // Re-checked after the wait: shutting down must not spend even one
+        // write on a child that may never drain it.
+        if stop.load(Ordering::Relaxed) || !write_cmd(&mut stdin, &cmd) {
+            return; // the child stopped listening; the reader will notice too
+        }
+    }
+    let _ = write_cmd(&mut stdin, &HostCmd::Shutdown);
+}
+
+/// One command onto the child's stdin; `false` once the pipe is gone.
+fn write_cmd(stdin: &mut ChildStdin, cmd: &HostCmd) -> bool {
+    let line = encode_host_cmd(cmd);
+    writeln!(stdin, "{line}").is_ok() && stdin.flush().is_ok()
+}
+
 /// The reader thread: frames in, shared state out. Never fails — a bad
 /// frame is skipped, an oversized one is counted, and EOF just ends the
 /// connection so the supervisor can respawn.
-fn read_frames<R: BufRead>(mut reader: R, shared: &Arc<Mutex<Shared>>, cmds: &Sender<HostCmd>) {
+fn read_frames<R: BufRead>(mut reader: R, shared: &Arc<Mutex<Shared>>, cmds: &SyncSender<HostCmd>) {
     let mut buf = Vec::new();
+    let mut reopened = false;
     loop {
         match read_frame(&mut reader, &mut buf) {
             Frame::Eof => return,
@@ -719,32 +849,42 @@ fn read_frames<R: BufRead>(mut reader: R, shared: &Arc<Mutex<Shared>>, cmds: &Se
         match applied {
             Applied::Nothing => {}
             Applied::Stop => return,
-            Applied::Reopen(tails) => {
+            // Once per connection, however many times the agent says hello:
+            // the tails were reopened on the first `Hello` and are still
+            // open on this same child, and a pane opened since sent its own
+            // `OpenTail`. Without this an agent spamming `Hello` queues one
+            // command per open pane per greeting.
+            Applied::Reopen(tails) if !reopened => {
+                reopened = true;
                 for (key, replay) in tails {
-                    let _ = cmds.send(HostCmd::OpenTail { key, replay });
+                    let _ = cmds.try_send(HostCmd::OpenTail { key, replay });
                 }
             }
+            Applied::Reopen(_) => {}
         }
     }
 }
 
-/// Drains a child's stderr into `buf`, capped at [`MAX_STDERR_BYTES`] — the
-/// stream is read to EOF either way (so the child never blocks on a full
-/// pipe), but bytes past the cap are dropped rather than grown into.
-fn read_stderr<R: BufRead>(mut reader: R, buf: &Mutex<String>) {
-    let mut line = String::new();
-    loop {
-        line.clear();
-        match reader.read_line(&mut line) {
-            Ok(0) | Err(_) => return,
-            Ok(_) => {
-                let mut guard = buf.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-                if guard.len() < MAX_STDERR_BYTES {
-                    guard.push_str(&line);
-                }
-            }
-        }
+/// Drains a child's stderr into `buf`, capped at [`MAX_STDERR_BYTES`], and
+/// returns how many bytes past the cap were thrown away.
+///
+/// The cap is enforced by [`Read::take`] *before* the read, not by checking
+/// the buffer afterwards: stderr drains from the moment the child is spawned,
+/// ahead of the `Hello` gate and every protocol cap, so a child writing to
+/// fd 2 with no newline in sight (`yes A | tr -d '\n' >&2`) would otherwise
+/// grow one `String` at pipe speed until the host is out of memory. The rest
+/// of the stream is still drained to EOF, into a sink, so the child never
+/// blocks on a full pipe and its exit stays the thing that ends this thread.
+fn read_stderr<R: BufRead>(mut reader: R, buf: &Mutex<String>) -> u64 {
+    let mut kept = Vec::new();
+    let _ = (&mut reader)
+        .take(MAX_STDERR_BYTES as u64)
+        .read_to_end(&mut kept);
+    {
+        let mut guard = buf.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard.push_str(&String::from_utf8_lossy(&kept));
     }
+    io::copy(&mut reader, &mut io::sink()).unwrap_or(0)
 }
 
 /// Whether a child's stderr reads as the shell's or `exec(2)`'s own "no such
@@ -978,7 +1118,7 @@ mod tests {
             "C:1".into(),
             TailQueue {
                 replay: Replay { bytes: 7, rows: 3 },
-                lines: VecDeque::new(),
+                ..TailQueue::default()
             },
         );
         assert_eq!(
@@ -1054,12 +1194,165 @@ mod tests {
         );
     }
 
+    /// The line cap alone is a cap on nothing: the agent picks how long a
+    /// line is, so 4096 of them is gigabytes. Both caps, whichever trips.
+    #[test]
+    fn tail_frames_are_bounded_in_bytes_not_just_in_lines() {
+        let mut shared = connected();
+        shared.tails.insert("C:1".into(), TailQueue::default());
+        let big = "x".repeat(MAX_TAIL_LINE_BYTES);
+        for _ in 0..500 {
+            apply_frame(
+                &mut shared,
+                AgentMsg::Tail {
+                    key: "C:1".into(),
+                    lines: vec![StyledLine(vec![Seg::new(Sem::Plain, big.clone())]); 4],
+                },
+                0.0,
+            );
+        }
+        let queue = &shared.tails["C:1"];
+        let held: usize = queue.lines.iter().map(StyledLine::byte_len).sum();
+        assert!(
+            queue.lines.len() < MAX_TAIL_LINES,
+            "the line cap never trips: {} lines",
+            queue.lines.len()
+        );
+        assert!(held <= MAX_TAIL_BYTES, "{held} bytes held");
+        assert_eq!(queue.bytes, held, "the running total tracks the queue");
+    }
+
+    /// One frame's worth of line — a megabyte the frame cap does allow —
+    /// is clipped at ingest, so no single retained line is unbounded.
+    #[test]
+    fn one_enormous_tail_line_is_clipped_at_ingest() {
+        let mut shared = connected();
+        shared.tails.insert("C:1".into(), TailQueue::default());
+        apply_frame(
+            &mut shared,
+            AgentMsg::Tail {
+                key: "C:1".into(),
+                lines: vec![StyledLine(vec![
+                    Seg::new(Sem::Plain, "y".repeat(MAX_FRAME_BYTES / 2)),
+                    Seg::new(Sem::Plain, "z".repeat(MAX_FRAME_BYTES / 2)),
+                ])],
+            },
+            0.0,
+        );
+        let line = &shared.tails["C:1"].lines[0];
+        assert_eq!(line.byte_len(), MAX_TAIL_LINE_BYTES);
+        assert!(
+            line.to_plain().starts_with("yyy"),
+            "the head is what's kept"
+        );
+    }
+
+    /// Sanitizing *grows* hostile text — one ESC byte becomes a three-byte
+    /// U+FFFD — so the cap has to be measured after it, not before.
+    #[test]
+    fn a_line_of_control_bytes_cannot_expand_past_the_clip() {
+        let escapes = "\x1b".repeat(MAX_TAIL_LINE_BYTES);
+        let line = sanitize_line(StyledLine(vec![Seg {
+            sem: Sem::Plain,
+            text: escapes,
+        }]));
+        assert!(line.byte_len() <= MAX_TAIL_LINE_BYTES);
+        assert!(line.to_plain().chars().all(|c| c == '\u{FFFD}'));
+    }
+
+    #[test]
+    fn draining_a_tail_queue_resets_its_byte_total() {
+        let shared = Arc::new(Mutex::new(connected()));
+        lock(&shared)
+            .tails
+            .insert("C:1".into(), TailQueue::default());
+        apply_frame(
+            &mut lock(&shared),
+            AgentMsg::Tail {
+                key: "C:1".into(),
+                lines: vec![StyledLine(vec![Seg::new(Sem::Plain, "hello")])],
+            },
+            0.0,
+        );
+        assert_eq!(lock(&shared).tails["C:1"].bytes, 5);
+
+        let (cmds, _rx) = mpsc::sync_channel(CMD_QUEUE);
+        let mut tailer = RemoteTailer {
+            key: "C:1".into(),
+            shared: Arc::clone(&shared),
+            cmds,
+            down_notified: false,
+        };
+        assert_eq!(tailer.poll().len(), 1);
+        assert_eq!(lock(&shared).tails["C:1"].bytes, 0);
+    }
+
     #[test]
     fn bye_ends_the_connection() {
         let mut shared = connected();
         assert_eq!(
             apply_frame(&mut shared, AgentMsg::Bye { reason: "x".into() }, 0.0),
             Applied::Stop
+        );
+    }
+
+    // ------------------------------------------------------- host commands
+
+    #[test]
+    fn an_agent_spamming_hello_cannot_queue_a_command_per_greeting() {
+        // Every `Hello` asks for one `OpenTail` per open pane. Ten thousand
+        // greetings with three panes open is thirty thousand commands the
+        // host would otherwise queue for a child that need never read one.
+        let shared = Arc::new(Mutex::new(connected()));
+        for key in ["C:1", "C:2", "C:3"] {
+            lock(&shared)
+                .tails
+                .insert(key.to_string(), TailQueue::default());
+        }
+        let (cmds, rx) = mpsc::sync_channel(CMD_QUEUE);
+        let line = crate::remote::proto::encode_agent_msg(&hello(PROTO_VERSION));
+        let stream = format!("{line}\n").repeat(10_000);
+
+        read_frames(Cursor::new(stream.into_bytes()), &shared, &cmds);
+
+        assert_eq!(
+            rx.try_iter().count(),
+            3,
+            "one reopen per open tail, for the whole connection"
+        );
+    }
+
+    /// The command channel is bounded and teardown never waits on the child:
+    /// a transport that never reads its stdin and never exits is exactly what
+    /// a hostile container is, and hermon still has to be able to quit.
+    #[test]
+    fn a_child_that_never_reads_its_stdin_can_neither_grow_nor_wedge_the_host() {
+        let mut transport = Command::new("sh");
+        transport.args(["-c", "exec sleep 30"]);
+        let remote = RemoteSource::new("job1", transport);
+
+        let sent = (0..10_000)
+            .filter(|i| {
+                remote
+                    .cmds
+                    .try_send(HostCmd::OpenTail {
+                        key: format!("C:{i}"),
+                        replay: Replay::default(),
+                    })
+                    .is_ok()
+            })
+            .count();
+        assert!(
+            sent < 10_000,
+            "the queue is bounded: a flood is refused, not buffered ({sent} accepted)"
+        );
+
+        let started = Instant::now();
+        drop(remote);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "Drop joined a thread parked on a write nobody was reading: {:?}",
+            started.elapsed()
         );
     }
 
@@ -1235,6 +1528,47 @@ mod tests {
         ] {
             assert!(looks_like_missing_binary(stderr), "{stderr:?}");
         }
+    }
+
+    #[test]
+    fn a_short_stderr_diagnostic_is_kept_whole() {
+        let buf = Mutex::new(String::new());
+        let dropped = read_stderr(Cursor::new(b"sh: 1: hermon: not found\n".to_vec()), &buf);
+        assert_eq!(dropped, 0);
+        assert_eq!(
+            buf.into_inner().unwrap(),
+            "sh: 1: hermon: not found\n",
+            "the diagnosis this reader exists for still arrives"
+        );
+    }
+
+    /// stderr drains from the moment the child is spawned — ahead of `Hello`
+    /// and every protocol cap — so a child writing to fd 2 with no newline in
+    /// sight (`yes A | tr -d '\n' >&2`) is the earliest unbounded allocation
+    /// a hostile container can reach. The cap has to be on the read itself.
+    #[test]
+    fn stderr_with_no_newline_in_it_is_read_under_the_cap_not_after() {
+        let flood = vec![b'A'; MAX_STDERR_BYTES * 16];
+        let buf = Mutex::new(String::new());
+        let dropped = read_stderr(Cursor::new(flood), &buf);
+        assert_eq!(buf.into_inner().unwrap().len(), MAX_STDERR_BYTES);
+        assert_eq!(dropped, (MAX_STDERR_BYTES * 15) as u64);
+    }
+
+    #[test]
+    fn dropped_stderr_is_counted_for_the_deck() {
+        let mut shared = connected();
+        shared.stderr_dropped = 99;
+        assert!(
+            notices("job1", &shared)
+                .iter()
+                .any(|n| n.contains("dropped 99 stderr byte(s)")),
+            "{:?}",
+            notices("job1", &shared)
+        );
+        // …and a fresh connection starts the count over.
+        apply_frame(&mut shared, hello(PROTO_VERSION), 0.0);
+        assert_eq!(notices("job1", &shared), Vec::<String>::new());
     }
 
     #[test]

--- a/src/remote/source.rs
+++ b/src/remote/source.rs
@@ -24,7 +24,7 @@
 //! trusted.
 
 use std::collections::{HashMap, VecDeque};
-use std::io::{self, BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender};
@@ -64,6 +64,14 @@ const MAX_TAIL_BYTES: usize = 4 * 1024 * 1024;
 /// a screenful; the rest is a hostile agent spending our memory a megabyte
 /// per frame.
 const MAX_TAIL_LINE_BYTES: usize = 64 * 1024;
+
+/// Most segments the host keeps from one wire line. The byte caps measure
+/// [`StyledLine::byte_len`], which now counts segment overhead, but the
+/// agent picks the segment *count* freely and a line of 45k empty segments
+/// arrives inside one frame: capping the count too keeps the worst single
+/// retained line bounded in structure as well as in text. A drawn line
+/// changes style a handful of times; a thousand is already absurd.
+const MAX_TAIL_SEGMENTS_PER_LINE: usize = 1024;
 
 /// Host commands queued for a child before new ones are dropped. Bounded
 /// because the agent influences how many get queued — every `Hello` asks for
@@ -155,6 +163,11 @@ struct Shared {
     oversized: u64,
     /// Stderr bytes read past [`MAX_STDERR_BYTES`] and thrown away — a child
     /// shouting into fd 2 to grow host memory, in the numbers that says so.
+    ///
+    /// Committed as the flood is drained, not at teardown, and never reset:
+    /// an agent that floods fd 2 while staying connected is exactly the case
+    /// the operator needs told, and a count that only landed when the
+    /// connection ended told them nothing until the agent chose to leave.
     stderr_dropped: u64,
     /// The newest `Snap` was truncated at [`MAX_SNAP_SESSIONS`].
     truncated: bool,
@@ -432,14 +445,17 @@ fn sanitize_meta(mut s: SessionMeta) -> SessionMeta {
 
 /// Rebuilding the line through [`sanitize`] is the laundering — the wire's
 /// own segments are never stored as-is — and the result is clipped to
-/// [`MAX_TAIL_LINE_BYTES`]. The clip goes here, on the sanitized text,
-/// because sanitizing *grows* a hostile line: every control byte becomes a
-/// three-byte U+FFFD, so a cap applied to what arrived would not bound what
-/// we keep.
+/// [`MAX_TAIL_LINE_BYTES`] of text across at most
+/// [`MAX_TAIL_SEGMENTS_PER_LINE`] segments. The clip goes here, on the
+/// sanitized text, because sanitizing *grows* a hostile line: every control
+/// byte becomes a three-byte U+FFFD, so a cap applied to what arrived would
+/// not bound what we keep. The segment cap is the same argument for the
+/// other axis: empty segments cost no text and still cost memory.
 fn sanitize_line(line: StyledLine) -> StyledLine {
     let mut budget = MAX_TAIL_LINE_BYTES;
-    let mut segs = Vec::with_capacity(line.0.len());
-    for seg in line.0 {
+    let kept = line.0.len().min(MAX_TAIL_SEGMENTS_PER_LINE);
+    let mut segs = Vec::with_capacity(kept);
+    for seg in line.0.into_iter().take(MAX_TAIL_SEGMENTS_PER_LINE) {
         if budget == 0 {
             break;
         }
@@ -553,8 +569,10 @@ fn apply_frame(shared: &mut Shared, msg: AgentMsg, now: f64) -> Applied {
             };
             // A fresh Hello resets everything that described the *previous*
             // connection; the snapshot stays, so the deck doesn't blink.
+            // `stderr_dropped` is deliberately not among them: it is a
+            // running total for the remote's whole life, so an agent cannot
+            // erase the evidence of a flood by reconnecting.
             shared.oversized = 0;
-            shared.stderr_dropped = 0;
             shared.truncated = false;
             shared.skew = None;
             shared.spawn_error = None;
@@ -731,12 +749,17 @@ fn run_connection(
     stop: &Arc<AtomicBool>,
 ) -> String {
     let reading = Arc::new(AtomicBool::new(true));
+    // Cleared when this connection is done with, whether its threads have
+    // ended or been abandoned — an orphan reader must not keep folding a
+    // dead child's frames into the state of the connection that replaced it.
+    let live = Arc::new(AtomicBool::new(true));
     let reader = child.stdout.take().map(|stdout| {
         let shared = Arc::clone(shared);
         let cmds = cmds.clone();
         let reading = Arc::clone(&reading);
+        let live = Arc::clone(&live);
         thread::spawn(move || {
-            read_frames(BufReader::new(stdout), &shared, &cmds);
+            read_frames(BufReader::new(stdout), &shared, &cmds, &live);
             reading.store(false, Ordering::Relaxed);
         })
     });
@@ -744,7 +767,12 @@ fn run_connection(
     let stderr_buf = Arc::new(Mutex::new(String::new()));
     let stderr_reader = child.stderr.take().map(|stderr| {
         let buf = Arc::clone(&stderr_buf);
-        thread::spawn(move || read_stderr(BufReader::new(stderr), &buf))
+        let shared = Arc::clone(shared);
+        thread::spawn(move || {
+            read_stderr(BufReader::new(stderr), &buf, |n| {
+                lock(&shared).stderr_dropped += n;
+            });
+        })
     });
 
     let writer = child.stdin.take().map(|stdin| {
@@ -768,22 +796,35 @@ fn run_connection(
     }
     let _ = child.kill();
     let _ = child.wait();
-    if let Some(reader) = reader {
-        let _ = reader.join();
-    }
-    if let Some(writer) = writer {
-        let _ = writer.join();
-    }
-    if let Some(reader) = stderr_reader
-        && let Ok(dropped) = reader.join()
-        && dropped > 0
-    {
-        lock(shared).stderr_dropped += dropped;
+    live.store(false, Ordering::Relaxed);
+    // Killing the child normally closes its pipes, and these three threads
+    // end on the EOF that follows — but a `cmd:` child that forked a
+    // grandchild holding our stdout leaves the write end open past its own
+    // death, and no EOF ever comes. Bounded, then, and abandoned on expiry:
+    // a leaked thread parked on a read it will never finish costs one stack,
+    // where joining it costs the operator a hermon that cannot be quit.
+    let deadline = Instant::now() + SHUTDOWN_GRACE;
+    for handle in [reader, writer, stderr_reader].into_iter().flatten() {
+        join_before(handle, deadline);
     }
     stderr_buf
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .clone()
+}
+
+/// Joins a connection thread, but only until `deadline`; a thread still
+/// running then is detached and left to end whenever its blocked read or
+/// write does. Nothing downstream waits on the result — the state these
+/// threads write is behind an `Arc<Mutex<_>>` that outlives them either way.
+fn join_before(handle: JoinHandle<()>, deadline: Instant) {
+    while !handle.is_finished() {
+        if Instant::now() >= deadline {
+            return;
+        }
+        thread::sleep(CMD_TICK.min(deadline.saturating_duration_since(Instant::now())));
+    }
+    let _ = handle.join();
 }
 
 /// Host commands onto one child's stdin, on a thread of their own.
@@ -829,10 +870,20 @@ fn write_cmd(stdin: &mut ChildStdin, cmd: &HostCmd) -> bool {
 /// The reader thread: frames in, shared state out. Never fails — a bad
 /// frame is skipped, an oversized one is counted, and EOF just ends the
 /// connection so the supervisor can respawn.
-fn read_frames<R: BufRead>(mut reader: R, shared: &Arc<Mutex<Shared>>, cmds: &SyncSender<HostCmd>) {
+///
+/// `live` is this connection's own flag, checked once per frame: a reader
+/// abandoned by [`join_before`] may still be parked on a pipe a grandchild
+/// holds open, and its child's frames must not reach a state that has since
+/// moved on to a new connection.
+fn read_frames<R: BufRead>(
+    mut reader: R,
+    shared: &Arc<Mutex<Shared>>,
+    cmds: &SyncSender<HostCmd>,
+    live: &AtomicBool,
+) {
     let mut buf = Vec::new();
     let mut reopened = false;
-    loop {
+    while live.load(Ordering::Relaxed) {
         match read_frame(&mut reader, &mut buf) {
             Frame::Eof => return,
             Frame::Oversized => {
@@ -873,9 +924,14 @@ fn read_frames<R: BufRead>(mut reader: R, shared: &Arc<Mutex<Shared>>, cmds: &Sy
 /// ahead of the `Hello` gate and every protocol cap, so a child writing to
 /// fd 2 with no newline in sight (`yes A | tr -d '\n' >&2`) would otherwise
 /// grow one `String` at pipe speed until the host is out of memory. The rest
-/// of the stream is still drained to EOF, into a sink, so the child never
-/// blocks on a full pipe and its exit stays the thing that ends this thread.
-fn read_stderr<R: BufRead>(mut reader: R, buf: &Mutex<String>) -> u64 {
+/// of the stream is still drained to EOF so the child never blocks on a full
+/// pipe and its exit stays the thing that ends this thread.
+///
+/// The surplus is reported through `commit` as it is discarded rather than
+/// only returned at EOF: a flooding agent that stays connected never reaches
+/// EOF, and a notice the operator sees only once the agent decides to leave
+/// is a notice about the wrong thing.
+fn read_stderr<R: BufRead>(mut reader: R, buf: &Mutex<String>, mut commit: impl FnMut(u64)) -> u64 {
     let mut kept = Vec::new();
     let _ = (&mut reader)
         .take(MAX_STDERR_BYTES as u64)
@@ -884,7 +940,19 @@ fn read_stderr<R: BufRead>(mut reader: R, buf: &Mutex<String>) -> u64 {
         let mut guard = buf.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         guard.push_str(&String::from_utf8_lossy(&kept));
     }
-    io::copy(&mut reader, &mut io::sink()).unwrap_or(0)
+    // The reader's own buffer is the sink: consuming what it already holds
+    // costs no allocation and no copy, and each chunk is reported before the
+    // next read parks this thread waiting for one.
+    let mut dropped = 0;
+    loop {
+        let chunk = match reader.fill_buf() {
+            Ok([]) | Err(_) => return dropped,
+            Ok(chunk) => chunk.len(),
+        };
+        reader.consume(chunk);
+        dropped += chunk as u64;
+        commit(chunk as u64);
+    }
 }
 
 /// Whether a child's stderr reads as the shell's or `exec(2)`'s own "no such
@@ -919,6 +987,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
+    use crate::render::SEG_OVERHEAD;
 
     fn meta(id: &str) -> SessionMeta {
         SessionMeta {
@@ -1240,11 +1309,52 @@ mod tests {
             0.0,
         );
         let line = &shared.tails["C:1"].lines[0];
-        assert_eq!(line.byte_len(), MAX_TAIL_LINE_BYTES);
+        // One segment survives: it exhausts the text budget, so the second
+        // is dropped whole.
+        assert_eq!(line.byte_len(), MAX_TAIL_LINE_BYTES + SEG_OVERHEAD);
         assert!(
             line.to_plain().starts_with("yyy"),
             "the head is what's kept"
         );
+    }
+
+    /// The byte cap counts segment overhead, and the segment count is the
+    /// agent's to choose: 45k empty segments per line is one frame's worth of
+    /// wire and gigabytes of host memory when only text is measured.
+    #[test]
+    fn tail_frames_are_bounded_in_segments_not_just_in_text() {
+        let mut shared = connected();
+        shared.tails.insert("C:1".into(), TailQueue::default());
+        let storm = StyledLine(vec![Seg::new(Sem::Ok, ""); 45_000]);
+        for _ in 0..981 {
+            apply_frame(
+                &mut shared,
+                AgentMsg::Tail {
+                    key: "C:1".into(),
+                    lines: vec![storm.clone()],
+                },
+                0.0,
+            );
+        }
+        let queue = &shared.tails["C:1"];
+        let held: usize = queue.lines.iter().map(StyledLine::byte_len).sum();
+        assert!(held > 0, "empty segments are not free");
+        assert!(held <= MAX_TAIL_BYTES, "{held} bytes held");
+        assert!(
+            queue.lines.len() < MAX_TAIL_LINES,
+            "the byte cap trips first, not the line cap: {} lines",
+            queue.lines.len()
+        );
+        assert_eq!(queue.bytes, held, "the running total tracks the queue");
+    }
+
+    /// No single wire line may carry an unbounded segment count through
+    /// either cap: the count is clipped at ingest, like the text is.
+    #[test]
+    fn one_segment_storm_line_is_clipped_at_ingest() {
+        let line = sanitize_line(StyledLine(vec![Seg::new(Sem::Ok, ""); 10_000]));
+        assert_eq!(line.0.len(), MAX_TAIL_SEGMENTS_PER_LINE);
+        assert_eq!(line.byte_len(), MAX_TAIL_SEGMENTS_PER_LINE * SEG_OVERHEAD);
     }
 
     /// Sanitizing *grows* hostile text — one ESC byte becomes a three-byte
@@ -1256,7 +1366,7 @@ mod tests {
             sem: Sem::Plain,
             text: escapes,
         }]));
-        assert!(line.byte_len() <= MAX_TAIL_LINE_BYTES);
+        assert!(line.byte_len() <= MAX_TAIL_LINE_BYTES + SEG_OVERHEAD);
         assert!(line.to_plain().chars().all(|c| c == '\u{FFFD}'));
     }
 
@@ -1274,7 +1384,7 @@ mod tests {
             },
             0.0,
         );
-        assert_eq!(lock(&shared).tails["C:1"].bytes, 5);
+        assert_eq!(lock(&shared).tails["C:1"].bytes, SEG_OVERHEAD + 5);
 
         let (cmds, _rx) = mpsc::sync_channel(CMD_QUEUE);
         let mut tailer = RemoteTailer {
@@ -1313,7 +1423,8 @@ mod tests {
         let line = crate::remote::proto::encode_agent_msg(&hello(PROTO_VERSION));
         let stream = format!("{line}\n").repeat(10_000);
 
-        read_frames(Cursor::new(stream.into_bytes()), &shared, &cmds);
+        let live = AtomicBool::new(true);
+        read_frames(Cursor::new(stream.into_bytes()), &shared, &cmds, &live);
 
         assert_eq!(
             rx.try_iter().count(),
@@ -1533,7 +1644,11 @@ mod tests {
     #[test]
     fn a_short_stderr_diagnostic_is_kept_whole() {
         let buf = Mutex::new(String::new());
-        let dropped = read_stderr(Cursor::new(b"sh: 1: hermon: not found\n".to_vec()), &buf);
+        let dropped = read_stderr(
+            Cursor::new(b"sh: 1: hermon: not found\n".to_vec()),
+            &buf,
+            |_| unreachable!("nothing is dropped under the cap"),
+        );
         assert_eq!(dropped, 0);
         assert_eq!(
             buf.into_inner().unwrap(),
@@ -1550,7 +1665,7 @@ mod tests {
     fn stderr_with_no_newline_in_it_is_read_under_the_cap_not_after() {
         let flood = vec![b'A'; MAX_STDERR_BYTES * 16];
         let buf = Mutex::new(String::new());
-        let dropped = read_stderr(Cursor::new(flood), &buf);
+        let dropped = read_stderr(Cursor::new(flood), &buf, |_| {});
         assert_eq!(buf.into_inner().unwrap().len(), MAX_STDERR_BYTES);
         assert_eq!(dropped, (MAX_STDERR_BYTES * 15) as u64);
     }
@@ -1566,9 +1681,99 @@ mod tests {
             "{:?}",
             notices("job1", &shared)
         );
-        // …and a fresh connection starts the count over.
+        // …and reconnecting does not erase it: the count is the remote's
+        // running total, not this connection's.
         apply_frame(&mut shared, hello(PROTO_VERSION), 0.0);
-        assert_eq!(notices("job1", &shared), Vec::<String>::new());
+        assert!(
+            notices("job1", &shared)
+                .iter()
+                .any(|n| n.contains("dropped 99 stderr byte(s)")),
+            "a fresh Hello must not clear the evidence: {:?}",
+            notices("job1", &shared)
+        );
+    }
+
+    /// An agent that floods fd 2 and stays connected never reaches teardown,
+    /// so a count committed only on the way out is a count the operator
+    /// never sees while it matters.
+    #[test]
+    fn a_flood_from_a_connected_agent_surfaces_a_notice_before_teardown() {
+        let shared = Arc::new(Mutex::new(connected()));
+        let buf = Mutex::new(String::new());
+        let flood = vec![b'A'; MAX_STDERR_BYTES * 4];
+
+        // Mid-flood — the reader is still draining, the child still alive —
+        // the deck already says so.
+        let mut seen_mid_flood = Vec::new();
+        read_stderr(Cursor::new(flood), &buf, |n| {
+            lock(&shared).stderr_dropped += n;
+            if seen_mid_flood.is_empty() {
+                seen_mid_flood = notices("job1", &lock(&shared));
+            }
+        });
+
+        assert!(
+            seen_mid_flood
+                .iter()
+                .any(|n| n.contains("stderr byte(s) over")),
+            "{seen_mid_flood:?}"
+        );
+        assert_eq!(
+            lock(&shared).stderr_dropped,
+            (MAX_STDERR_BYTES * 3) as u64,
+            "and the running total is the whole surplus"
+        );
+    }
+
+    /// The same property through a real child: it floods fd 2 and then keeps
+    /// running, so nothing about this connection is ever torn down. A count
+    /// that only landed at teardown left the operator with nothing to see for
+    /// as long as the agent chose to stay.
+    #[test]
+    fn a_flood_is_on_the_deck_while_the_child_is_still_running() {
+        let mut transport = Command::new("sh");
+        // 200 KiB onto stderr, then thirty seconds of nothing.
+        transport.args([
+            "-c",
+            "i=0; while [ $i -lt 200 ]; do printf '%1000s' '' >&2; i=$((i+1)); done; sleep 30",
+        ]);
+        let remote = RemoteSource::new("job1", transport);
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut noticed = false;
+        while Instant::now() < deadline && !noticed {
+            noticed = remote
+                .notices()
+                .iter()
+                .any(|n| n.contains("stderr byte(s) over"));
+            thread::sleep(CMD_TICK);
+        }
+        assert!(
+            noticed,
+            "the flood stayed invisible while the child ran: {:?}",
+            remote.notices()
+        );
+    }
+
+    /// A `cmd:` child that forks a grandchild holding our stdout gives no
+    /// EOF when it dies, and a reader parked on that pipe used to make
+    /// hermon unquittable. Teardown bounds the wait and abandons the thread.
+    #[test]
+    fn a_child_that_leaves_its_pipe_open_cannot_wedge_teardown() {
+        // The `sh` exits at once; the backgrounded `sleep` inherits stdout
+        // and holds the write end open for two minutes.
+        let mut transport = Command::new("sh");
+        transport.args(["-c", "sleep 120 & exit 0"]);
+        let remote = RemoteSource::new("job1", transport);
+        thread::sleep(Duration::from_millis(200));
+
+        let started = Instant::now();
+        drop(remote);
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "Drop waited {:?} on an orphan's pipe",
+            started.elapsed()
+        );
     }
 
     #[test]

--- a/src/remote/spec.rs
+++ b/src/remote/spec.rs
@@ -29,6 +29,8 @@
 use std::fmt;
 use std::process::Command;
 
+use crate::remote::source::clean_name;
+
 /// `hermon agent`'s argv0 at the far end of a `docker:`/`ssh:` transport —
 /// found on the remote's `PATH`, never a path the host resolves itself.
 ///
@@ -79,7 +81,8 @@ pub fn parse_spec(spec: &str) -> Result<RemoteSpec, SpecError> {
             let (container, name) = split_name_suffix(rest);
             validate_name(container).map_err(|e| SpecError(format!("--remote {spec:?}: {e}")))?;
             Ok(RemoteSpec {
-                name: name.unwrap_or(container).to_string(),
+                name: display_name(name, container)
+                    .map_err(|e| SpecError(format!("--remote {spec:?}: {e}")))?,
                 kind: Kind::Docker {
                     container: container.to_string(),
                 },
@@ -89,7 +92,8 @@ pub fn parse_spec(spec: &str) -> Result<RemoteSpec, SpecError> {
             let (host, name) = split_name_suffix(rest);
             validate_name(host).map_err(|e| SpecError(format!("--remote {spec:?}: {e}")))?;
             Ok(RemoteSpec {
-                name: name.unwrap_or(host).to_string(),
+                name: display_name(name, host)
+                    .map_err(|e| SpecError(format!("--remote {spec:?}: {e}")))?,
                 kind: Kind::Ssh {
                     host: host.to_string(),
                 },
@@ -103,7 +107,7 @@ pub fn parse_spec(spec: &str) -> Result<RemoteSpec, SpecError> {
                     "--remote {spec:?}: cmd: needs at least one word"
                 )));
             };
-            let name = first.rsplit('/').next().unwrap_or(first).to_string();
+            let name = clean_name(first.rsplit('/').next().unwrap_or(first));
             Ok(RemoteSpec {
                 name,
                 kind: Kind::Cmd { argv },
@@ -133,6 +137,27 @@ pub fn parse_specs(specs: &[String]) -> Result<Vec<RemoteSpec>, SpecError> {
         out.push(parsed);
     }
     Ok(out)
+}
+
+/// The roster prefix a spec ends up with: the `:name` suffix if there is
+/// one, cleaned exactly as [`RemoteSource::new`] would clean it and then
+/// validated, otherwise the container/host itself.
+///
+/// The cleaning is the point. `RemoteSource::new` runs [`clean_name`] over
+/// whatever name it is handed, so a suffix taken verbatim here would leave
+/// `RemoteSpec::name` naming a remote that does not exist — and the
+/// explicit-wins collision check in [`crate::engine`] keys off exactly that
+/// string, so a `dev.hermon.agent.name` label matching the *cleaned* name
+/// would slip past it and spawn a second remote under the user's own prefix.
+///
+/// [`RemoteSource::new`]: crate::remote::source::RemoteSource::new
+fn display_name(suffix: Option<&str>, default: &str) -> Result<String, SpecError> {
+    let Some(raw) = suffix else {
+        return Ok(default.to_string());
+    };
+    let name = clean_name(raw);
+    validate_name(&name)?;
+    Ok(name)
 }
 
 /// Splits `container[:name]` / `host[:name]` on the first colon: everything
@@ -442,17 +467,46 @@ mod tests {
 
     #[test]
     fn a_colon_in_the_ssh_host_position_becomes_a_name_suffix_not_a_second_host() {
-        // The name suffix never reaches argv (only `host` does), so even a
-        // hostile-looking suffix here is inert — it can only ever change
-        // the roster's display prefix.
-        let spec = parse_spec("ssh:buildbox:-oProxyCommand=evil").expect("parses");
-        assert_eq!(spec.name, "-oProxyCommand=evil");
+        // The name suffix never reaches argv (only `host` does): it can only
+        // ever change the roster's display prefix.
+        let spec = parse_spec("ssh:buildbox:ci-1").expect("parses");
+        assert_eq!(spec.name, "ci-1");
         let cmd = to_command(&spec, &[]);
         assert_eq!(
             args_of(&cmd),
             vec!["-o", "BatchMode=yes", "buildbox", "hermon", "agent"],
             "the name suffix never reaches the child's argv"
         );
+    }
+
+    #[test]
+    fn an_option_looking_name_suffix_is_rejected() {
+        // Inert in argv, but it is still the string the explicit-wins
+        // collision check keys on, so it is held to the same charset.
+        let err = parse_spec("ssh:buildbox:-oProxyCommand=evil").unwrap_err();
+        assert!(err.to_string().contains("cannot start with '-'"), "{err}");
+    }
+
+    #[test]
+    fn a_name_suffix_is_the_name_the_remote_will_actually_run_under() {
+        let spec = parse_spec("docker:job1:a/b").expect("parses");
+        assert_eq!(spec.name, "a-b", "cleaned here, not silently at spawn");
+        assert_eq!(
+            clean_name(&spec.name),
+            spec.name,
+            "RemoteSource::new cleans the name it is handed; a spec whose \
+             name survives that is a name some remote actually has"
+        );
+        assert_eq!(
+            args_of(&to_command(&spec, &[])),
+            vec!["exec", "-i", "job1", "hermon", "agent"]
+        );
+    }
+
+    #[test]
+    fn a_name_suffix_with_control_bytes_is_rejected() {
+        let err = parse_spec("docker:job1:a\x1bb").unwrap_err();
+        assert!(err.to_string().contains("disallowed character"), "{err}");
     }
 
     #[test]

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -129,6 +129,13 @@ impl StyledLine {
         self.0.iter().map(|seg| seg.text.as_str()).collect()
     }
 
+    /// How much memory the line's text costs. Retention caps count this
+    /// alongside line counts: one wire line can carry a megabyte, so a cap
+    /// in lines alone bounds nothing.
+    pub fn byte_len(&self) -> usize {
+        self.0.iter().map(|seg| seg.text.len()).sum()
+    }
+
     /// The line as 24-bit ANSI, for `hermon ls` on a color terminal
     /// (`hermon.py:70 c()`). Callers decide whether color is wanted —
     /// `NO_COLOR` and a non-tty stdout both mean [`to_plain`](Self::to_plain).

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -109,6 +109,11 @@ pub struct Seg {
     pub text: String,
 }
 
+/// What one [`Seg`] costs before a byte of its text: the struct itself,
+/// stored inline in the line's `Vec`. Measured rather than guessed — a
+/// [`Sem`] tag plus a `String` header is 32 bytes on a 64-bit target.
+pub const SEG_OVERHEAD: usize = size_of::<Seg>();
+
 impl Seg {
     pub fn new(sem: Sem, text: impl Into<String>) -> Self {
         Seg {
@@ -129,11 +134,14 @@ impl StyledLine {
         self.0.iter().map(|seg| seg.text.as_str()).collect()
     }
 
-    /// How much memory the line's text costs. Retention caps count this
-    /// alongside line counts: one wire line can carry a megabyte, so a cap
-    /// in lines alone bounds nothing.
+    /// How much memory the line costs: its segments *and* their text.
+    /// Retention caps count this alongside line counts, and both halves have
+    /// to be in it — one wire line can carry a megabyte of text, and it can
+    /// equally carry a million empty segments, since `{"sem":"Ok","text":""}`
+    /// is 23 bytes on the wire that buys a [`SEG_OVERHEAD`]-byte `Seg` a
+    /// text-only measure scores as free.
     pub fn byte_len(&self) -> usize {
-        self.0.iter().map(|seg| seg.text.len()).sum()
+        self.0.len() * SEG_OVERHEAD + self.0.iter().map(|seg| seg.text.len()).sum::<usize>()
     }
 
     /// The line as 24-bit ANSI, for `hermon ls` on a color terminal
@@ -224,6 +232,26 @@ mod tests {
     #[test]
     fn empty_line_is_empty_string() {
         assert_eq!(StyledLine::default().to_plain(), "");
+    }
+
+    /// A line of empty segments carries no text and still costs real memory.
+    /// The retention caps measure `byte_len`, so a text-only measure made
+    /// segment storms free: 45k of them per line, gigabytes of host RSS, and
+    /// every cap reading zero.
+    #[test]
+    fn byte_len_counts_segment_overhead_not_only_text() {
+        let empty = StyledLine(vec![Seg::new(Sem::Ok, ""); 1_000]);
+        assert_eq!(empty.to_plain(), "", "no text at all");
+        assert_eq!(empty.byte_len(), 1_000 * SEG_OVERHEAD);
+        assert!(
+            empty.byte_len() >= 16_000,
+            "empty segments must not be free: {}",
+            empty.byte_len()
+        );
+
+        let texted = StyledLine(vec![Seg::new(Sem::Plain, "abcde")]);
+        assert_eq!(texted.byte_len(), SEG_OVERHEAD + 5, "text still counts");
+        assert_eq!(StyledLine::default().byte_len(), 0);
     }
 
     #[test]

--- a/src/roster.rs
+++ b/src/roster.rs
@@ -468,7 +468,13 @@ pub(crate) fn totals_line(rows: &[RosterRow]) -> StyledLine {
         }
     };
 
-    let in_tok: u64 = rows.iter().map(|r| r.in_tok).sum();
+    // Saturating, not `sum()`: a remote's token counts are numbers a hostile
+    // agent picks, and two of them near u64::MAX would otherwise wrap to a
+    // small total in release and panic the engine thread in debug.
+    let in_tok: u64 = rows
+        .iter()
+        .map(|r| r.in_tok)
+        .fold(0u64, u64::saturating_add);
 
     let mut parts = Vec::new();
     if perm_wait > 0 {
@@ -768,6 +774,22 @@ mod tests {
         assert_eq!(
             totals_line(&rows).to_plain(),
             "1 live · 1 done · Σ $3.00 · 2,469,134 in"
+        );
+    }
+
+    #[test]
+    fn hostile_token_counts_saturate_instead_of_wrapping() {
+        // `in_tok` is a u64 straight off a remote's wire, so two sessions can
+        // be made to overflow the total: it must clamp, not wrap (release) or
+        // panic the poll loop (debug).
+        let mut a = row("C:aaaaaa", Liveness::Live);
+        let mut b = row("C:bbbbbb", Liveness::Live);
+        a.in_tok = u64::MAX;
+        b.in_tok = u64::MAX;
+        let total = totals_line(&[a, b]).to_plain();
+        assert!(
+            total.ends_with(&format!("{} in", commas(u64::MAX))),
+            "{total}"
         );
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -298,17 +298,16 @@ impl App {
     }
 
     /// Appends a fast tick's lines to a pane's buffer, dropping the oldest
-    /// past [`pane::SCROLLBACK`]. Lines for any other key are stale — in
-    /// flight when the pane closed — and discarded.
+    /// past [`pane::SCROLLBACK`] or [`pane::SCROLLBACK_BYTES`], whichever
+    /// trips first. Lines for any other key are stale — in flight when the
+    /// pane closed — and discarded.
     fn buffer_pane(&mut self, key: &str, lines: Vec<StyledLine>) {
         if !self.open_panes.iter().any(|open| open == key) {
             return;
         }
         let buffer = self.panes.entry(key.to_string()).or_default();
         buffer.extend(lines);
-        while buffer.len() > pane::SCROLLBACK {
-            buffer.pop_front();
-        }
+        pane::trim_scrollback(buffer);
     }
 
     /// The sessions the engine should be tailing: in list mode the selected
@@ -989,6 +988,25 @@ mod tests {
         assert_eq!(buffer.len(), pane::SCROLLBACK);
         assert_eq!(buffer.front().unwrap().to_plain(), "line 1000");
         assert_eq!(buffer.back().unwrap().to_plain(), "line 5999");
+    }
+
+    /// A line count caps nothing when a remote picks how long its lines are:
+    /// 2000 lines of 64 KiB is 130 MB in a buffer 40% full by line count.
+    #[test]
+    fn the_pane_buffer_is_capped_in_bytes_as_well_as_lines() {
+        let mut app = App::default();
+        app.apply_event(Event::Roster(vec![row("a")]));
+        let big = pane_line(&"x".repeat(64 * 1024));
+        for _ in 0..200 {
+            app.apply_event(Event::PaneLines {
+                key: "a".to_string(),
+                lines: vec![big.clone(); 10],
+            });
+        }
+        let buffer = &app.panes["a"];
+        let bytes: usize = buffer.iter().map(StyledLine::byte_len).sum();
+        assert!(buffer.len() < pane::SCROLLBACK, "the line cap never trips");
+        assert!(bytes <= pane::SCROLLBACK_BYTES, "{bytes} bytes held");
     }
 
     static HOOK_CALLS: Mutex<Vec<&'static str>> = Mutex::new(Vec::new());

--- a/src/ui/pane.rs
+++ b/src/ui/pane.rs
@@ -28,6 +28,26 @@ use crate::ui::palette;
 /// in either.
 pub const SCROLLBACK: usize = 5_000;
 
+/// Transcript *bytes* kept for an open pane, evicted oldest-first alongside
+/// [`SCROLLBACK`] — whichever cap trips first. A line count bounds nothing on
+/// its own: a remote's lines are as long as the remote makes them, so 5000 of
+/// them can be gigabytes. Roughly 800 bytes a line at the line cap, which is
+/// far more than a drawn line ever is.
+pub const SCROLLBACK_BYTES: usize = 4 * 1024 * 1024;
+
+/// Evicts oldest-first until a pane buffer is inside both scrollback caps.
+/// One function for both front ends: the buffer is the same shape and the
+/// input is the same hostile input in either.
+pub fn trim_scrollback(buffer: &mut VecDeque<StyledLine>) {
+    let mut bytes: usize = buffer.iter().map(StyledLine::byte_len).sum();
+    while buffer.len() > SCROLLBACK || bytes > SCROLLBACK_BYTES {
+        let Some(dropped) = buffer.pop_front() else {
+            break;
+        };
+        bytes -= dropped.byte_len();
+    }
+}
+
 /// A session's pane: what to draw and how far back it is scrolled.
 pub struct Pane<'a> {
     pub key: &'a str,

--- a/src/view.rs
+++ b/src/view.rs
@@ -392,7 +392,13 @@ fn key_cmp(a: &RosterRow, b: &RosterRow, key: SortKey) -> Ordering {
     match key {
         SortKey::Model => a.model.cmp(&b.model),
         SortKey::Tool => a.last_tool.cmp(&b.last_tool),
-        SortKey::InOut => (a.in_tok + a.out_tok).cmp(&(b.in_tok + b.out_tok)),
+        // Saturating: both counts come off a remote's wire, where nothing
+        // stops an agent reporting u64::MAX and panicking a debug build's
+        // sort out from under the roster.
+        SortKey::InOut => a
+            .in_tok
+            .saturating_add(a.out_tok)
+            .cmp(&b.in_tok.saturating_add(b.out_tok)),
         // A missing cost sorts before any known cost.
         SortKey::Cost => match (a.cost, b.cost) {
             (None, None) => Ordering::Equal,
@@ -501,6 +507,19 @@ mod tests {
                 "{key:?}"
             );
         }
+    }
+
+    /// The token counts are a remote agent's to choose, so their sum is not
+    /// an arithmetic the sort may overflow on.
+    #[test]
+    fn in_out_sort_survives_wire_controlled_token_counts() {
+        let mut rows = [row("a", 1), row("b", 2), row("c", 3)];
+        rows[1].in_tok = u64::MAX;
+        rows[1].out_tok = u64::MAX;
+        rows[2].in_tok = u64::MAX;
+        rows[2].out_tok = 1;
+        assert_eq!(sorted(&rows, SortKey::InOut, SortDir::Asc)[0], "a");
+        assert_eq!(sorted(&rows, SortKey::InOut, SortDir::Desc)[2], "a");
     }
 
     #[test]


### PR DESCRIPTION
You are fixing security findings from a pre-release review of the hermon Rust codebase (DrazThan/hermon, M10 remote-sources milestone, about to tag v0.3.0). An opus security reviewer BLOCKED the release with 6 verified findings. Your job: fix ALL SIX, add/update tests proving each fix, and leave every gate green.

Work ONLY in this worktree: /Users/taloz/code/hermon-wt/m10-secfix. Do NOT commit, push, or create branches. Leave all changes in the working tree.

The six findings (file:line, exact, from the review):

**1. BLOCKER — unbounded stderr read (src/remote/source.rs ~734-748).**
`read_stderr` uses `reader.read_line(&mut line)` with no `.take()`, and `MAX_STDERR_BYTES` (4096) is consulted only AFTER the line is read. A child writing to fd 2 without newlines (`yes A | tr -d '\n' >&2`) grows one String at pipe speed until OOM — reachable before Hello/protocol gates (stderr drains from spawn).
FIX: read under the cap — `(&mut reader).take(MAX_STDERR_BYTES as u64).read_to_string(...)` then drain the rest to EOF with `io::copy(&mut reader, &mut io::sink())` — or the same Take/read_until shape `read_frame` uses for stdout. Keep a per-remote stat of dropped stderr bytes.

**2. BLOCKER — unbounded host-command channel + blocking stdin write (src/remote/source.rs ~168, 666-677, 722-726).**
`cmds` is an unbounded `mpsc::channel()`. The reader thread pushes `Applied::Reopen` -> one OpenTail per open tail per Hello; the only consumer drains ONE command per loop iteration into the child's stdin with a blocking `writeln!`. A container spamming Hello (with >=1 pane open) (a) queues unbounded HostCmds (30k from 10k Hellos with 3 panes) and (b) once the child's stdin pipe fills and the child never reads, the blocking `writeln!` hangs forever — `stop` is checked at loop top, so `RemoteSource::drop` joins a thread that never returns and hermon can't quit (SIGKILL only). Teardown `writeln!(…Shutdown)` blocks the same way.
FIX: (a) bound the channel — `mpsc::sync_channel` with `try_send`, drop on full (a repeated OpenTail for the same key is idempotent anyway); coalesce Reopen so a second Hello doesn't queue a second copy. (b) guard the blocking write: check `stop` before writing, and on `would_block`/full abandon the child (break the loop) rather than hang the thread. Ensure `Drop`/teardown never blocks on a full stdin.

**3. HIGH — retention caps count lines, not bytes (src/remote/source.rs ~55, 517-521; src/ui/mod.rs ~309; src/gui/mod.rs ~329).**
`MAX_TAIL_LINES` is 4096 LINES, `pane::SCROLLBACK` 5000 LINES. A wire StyledLine can be ~1 MiB (and sanitize expands ESC to U+FFFD = 3 bytes each), so steady-state ceiling is ~4 GiB demux + ~5 GiB pane per open pane, not ~4 MB. Verified: 200 frames of one 64 KiB line = 13 MB in a queue whose cap is 4096 entries (5% full).
FIX: track bytes alongside lines in TailQueue and UI buffers, evict on whichever trips first; AND clip tail-line length at ingest in `sanitize_line` (a hard cap, e.g. 64 KiB per line, is the simplest sufficient guard). Add a test that N big lines don't exceed a byte ceiling.

**4. HIGH — docker auto-discovery identity hijack (src/remote/discover.rs ~210-217, 232-237; src/engine.rs ~170-177).**
`reconcile` resolves same-name collisions purely by iteration order (`claimed.insert`), then consults `managed`. `docker ps` lists newest-first, so a container started AFTER a legitimate one carrying `dev.hermon.agent.name=<victim name>` is processed first, wins the name, the victim hits the `claimed` branch and is torn down (removals apply before spawns). The victim's watched sessions are replaced by the attacker's under the same prefix. The logged warning blames the victim.
FIX: seed `claimed` from `managed` before the loop so an INCUMBENT container id keeps its name; a newcomer colliding with an incumbent is the loser (and is warned as the newcomer, not blamed). Add tests: later-starting spoofing container does not steal an incumbent's name; the incumbent survives.

**5. MEDIUM — `:name` suffix not validated, explicit-wins keyed on a name no remote has (src/remote/spec.rs ~79-96; src/remote/source.rs ~361-363; src/engine.rs ~268).**
`parse_spec` validates only container/host; the display-name suffix is taken verbatim, but `RemoteSource::new` applies `clean_name` (`/`->`-`, control->U+FFFD). `engine.rs:268` builds the `explicit` set from the pre-clean name. So `--remote docker:job1:a/b` gives explicit={"a/b"} but the live remote is "a-b"; a container labelled `dev.hermon.agent.name=a-b` passes validation, misses the collision check, and a second "a-b" RemoteSource is spawned — open_tailer routes by `.find()` so one shadows the other, and tearing down the discovered one ALSO removes the user's explicit remote.
FIX: run the `:name` suffix through `clean_name` (and validate it) in `parse_spec`, so the name in `RemoteSpec` is the name the RemoteSource will actually have. Add a test: `docker:job1:a/b` produces a spec named "a-b" and the explicit set keys on it.

**6. MEDIUM — remote-controlled u64 overflow in fleet totals (src/roster.rs ~471).**
`in_tok`/`out_tok` are u64 off the wire; `totals_line` does `.map(|r| r.in_tok).sum()`. Release profile has no `overflow-checks`, so two hostile sessions wrap silently (attacker-chosen number shown); debug panics on the engine thread killing the poll loop.
FIX: `fold(0u64, u64::saturating_add)` for both sums (and any other u64 sums in the same line), or clamp in sanitize_meta. Add a test with `u64::MAX` values that the total saturates rather than wrapping/panicking.

Do NOT attempt to fix anything beyond these six. The rest of the milestone is verified-hardened.

GATES — must all pass before you report done:
1. cargo build
2. cargo test (ALL suites green; run it fully, not just a subset)
3. cargo clippy --all-targets -- -D warnings (zero errors)
4. cargo fmt --check (run cargo fmt first)
5. Do not add dependencies.
6. Do not touch files outside the scope these fixes require.

When done, write a short summary: for each of the 6 findings, one line on the fix + the test that proves it, then the exact gate outputs. Verify the gates yourself; report their real output.